### PR TITLE
Make sure you can configure clients and register them as services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -10,25 +9,22 @@ php:
 env:
   global:
     - TEST_COMMAND="composer test"
+  matrix:
+    - SYMFONY_VERSION=3.0.*
+    - SYMFONY_VERSION=2.8.*
     - SYMFONY_VERSION=2.7.*
 
 matrix:
-  allow_failures:
-    - php: 7.0
   fast_finish: true
-  include:
-    - php: 5.4
-      env:
-        - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-        - COVERAGE=true
-        - TEST_COMMAND="composer test-ci"
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
+  allow_failures:
+    - php: hhvm
+    - env: SYMFONY_VERSION=3.0.*
+    - php: 5.5
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" && COVERAGE=true && TEST_COMMAND="composer test-ci" && SYMFONY_VERSION=2.7.*
 
 before_install:
   - travis_retry composer self-update
+  - wget https://github.com/puli/cli/releases/download/1.0.0-beta9/puli.phar && chmod +x puli.phar
 
 install:
   - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
@@ -40,4 +36,3 @@ script:
 after_success:
   - if [[ "$COVERAGE" = true ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
   - if [[ "$COVERAGE" = true ]]; then php ocular.phar code-coverage:upload --format=php-clover build/coverage.xml; fi
-

--- a/ClientFactory/ClientFactoryInterface.php
+++ b/ClientFactory/ClientFactoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Http\HttplugBundle\ClientFactory;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+interface ClientFactoryInterface
+{
+    /**
+     * Input an array of configuration to be able to create a HttpClient
+     *
+     * @param array $config
+     *
+     * @return \Http\Client\HttpClient
+     */
+    public function createClient(array $config = array());
+}

--- a/ClientFactory/DummyClient.php
+++ b/ClientFactory/DummyClient.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Http\HttplugBundle\ClientFactory;
+
+/**
+ * This client is used as a placeholder for the dependency injection. It will never be used.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class DummyClient
+{
+}

--- a/ClientFactory/Guzzle5Factory.php
+++ b/ClientFactory/Guzzle5Factory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Http\HttplugBundle\ClientFactory;
+
+use GuzzleHttp\Client;
+use Http\Adapter\Guzzle5\Client as Adapter;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class Guzzle5Factory
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createClient(array $config = [])
+    {
+        if (!class_exists('Http\Adapter\Guzzle5\Client')) {
+            throw new \LogicException('To use the Guzzle5 adapter you need to install the "php-http/guzzle5-adapter" package.');
+        }
+
+        $client = new Client($config);
+
+        return new Adapter($client);
+    }
+}

--- a/ClientFactory/Guzzle6Factory.php
+++ b/ClientFactory/Guzzle6Factory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Http\HttplugBundle\ClientFactory;
+
+use GuzzleHttp\Client;
+use Http\Adapter\Guzzle6\Client as Adapter;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class Guzzle6Factory implements ClientFactoryInterface
+{
+    public function createClient(array $config = [])
+    {
+        if (!class_exists('Http\Adapter\Guzzle6\Client')) {
+            throw new \LogicException('To use the Guzzle6 adapter you need to install the "php-http/guzzle6-adapter" package.');
+        }
+
+        $client = new Client($config);
+
+        return new Adapter($client);
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,12 +2,14 @@
 
 namespace Http\HttplugBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
- * This class contains the configuration information for the bundle
+ * This class contains the configuration information for the bundle.
  *
  * This information is solely responsible for how the different configuration
  * sections are normalized, and merged.
@@ -24,12 +26,15 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('httplug');
 
+        $this->configureClients($rootNode);
+
         $rootNode
             ->validate()
                 ->ifTrue(function ($v) {
                     return !empty($v['classes']['client'])
                         || !empty($v['classes']['message_factory'])
                         || !empty($v['classes']['uri_factory'])
+                        || !empty($v['classes']['stream_factory'])
                     ;
                 })
                 ->then(function ($v) {
@@ -54,6 +59,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('client')->defaultValue('httplug.client.default')->end()
                         ->scalarNode('message_factory')->defaultValue('httplug.message_factory.default')->end()
                         ->scalarNode('uri_factory')->defaultValue('httplug.uri_factory.default')->end()
+                        ->scalarNode('stream_factory')->defaultValue('httplug.stream_factory.default')->end()
                     ->end()
                 ->end()
                 ->arrayNode('classes')
@@ -63,11 +69,29 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('client')->defaultNull()->end()
                         ->scalarNode('message_factory')->defaultNull()->end()
                         ->scalarNode('uri_factory')->defaultNull()->end()
+                        ->scalarNode('stream_factory')->defaultNull()->end()
                     ->end()
                 ->end()
             ->end()
         ;
 
         return $treeBuilder;
+    }
+
+    protected function configureClients(ArrayNodeDefinition $root)
+    {
+        $root->children()
+            ->arrayNode('clients')
+                ->useAttributeAsKey('name')
+                ->prototype('array')
+                ->children()
+                    ->scalarNode('factory')
+                        ->isRequired()
+                        ->cannotBeEmpty()
+                        ->info('The service id of a factory to use when creating the adapter.')
+                    ->end()
+                    ->variableNode('config')->end()
+                ->end()
+            ->end();
     }
 }

--- a/Exception/InvalidConfiguration.php
+++ b/Exception/InvalidConfiguration.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Http\HttplugBundle\Exception;
+
+class InvalidConfiguration extends \Exception
+{
+}

--- a/HttplugBundle.php
+++ b/HttplugBundle.php
@@ -2,6 +2,7 @@
 
 namespace Http\HttplugBundle;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**

--- a/README.md
+++ b/README.md
@@ -41,11 +41,14 @@ For information how to write applications with the services provided by this bun
 
 ### Use in Applications
 
+#### Custom services
+
 This bundle provides 3 services: 
 
 * `httplug.client` a service that provides the `Http\Client\HttpClient`
 * `httplug.message_factory` a service that provides the `Http\Message\MessageFactory`
 * `httplug.uri_factory` a service that provides the `Http\Message\UriFactory`
+* `httplug.stream_factory` a service that provides the `Http\Message\StreamFactory`
 
 These services are always an alias to another service. You can specify your own service or leave the default, which is the same name with `.default` appended. The default services in turn use the service discovery mechanism to provide the best available implementation. You can specify a class for each of the default services to use instead of discovery, as long as those classes can be instantiated without arguments.
 
@@ -53,14 +56,47 @@ If you need a more custom setup, define the services in your application configu
 
 ```yaml
 httplug:
-    main_alias:
-        client: httplug.client.default
-        message_factory: httplug.message_factory.default
-        uri_factory: httplug.uri_factory.default
-    classes:
-        client: ~ # uses discovery if not specified
-        message_factory: ~
-        uri_factory: ~
+  main_alias:
+    client: httplug.client.default
+    message_factory: httplug.message_factory.default
+    uri_factory: httplug.uri_factory.default
+    stream_factory: httplug.stream_factory.default
+  classes:
+    # uses discovery if not specified
+    client: ~
+    message_factory: ~ 
+    uri_factory: ~
+    stream_factory: ~
+```
+
+#### Configure your client
+
+You can configure your clients with some good default options. The clients are later registered as services. 
+
+```yaml
+httplug:
+  clients: 
+    my_guzzle5: 
+      factory: 'httplug.factory.guzzle5'
+      config:
+        # These options are given to Guzzle without validation. 
+        base_url: 'http://google.se/'
+        defaults:
+          verify_ssl: false
+          timeout: 4
+          headers:
+            Content-Type: 'application/json'
+    acme: 
+      factory: 'httplug.factory.guzzle6'
+      config:
+        base_url: 'http://google.se/'
+       
+```
+
+```php
+
+$httpClient = $this->container->get('httplug.client.my_guzzle5');
+$httpClient = $this->container->get('httplug.client.acme');
 ```
 
 ### Use for Reusable Bundles

--- a/Resources/config/discovery.xml
+++ b/Resources/config/discovery.xml
@@ -16,6 +16,10 @@
              class="Http\Message\UriFactory">
             <factory class="Http\Discovery\UriFactoryDiscovery" method="find"/>
         </service>
+        <service id="httplug.stream_factory.default"
+             class="Http\Message\StreamFactory">
+            <factory class="Http\Discovery\StreamFactoryDiscovery" method="find"/>
+        </service>
 
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <!-- ClientFactories -->
+        <service id="httplug.factory.guzzle5" class="Http\HttplugBundle\ClientFactory\Guzzle5Factory" public="false" />
+        <service id="httplug.factory.guzzle6" class="Http\HttplugBundle\ClientFactory\Guzzle6Factory" public="false" />
+    </services>
+</container>

--- a/Tests/Resources/Fixtures/config/full.php
+++ b/Tests/Resources/Fixtures/config/full.php
@@ -5,10 +5,12 @@ $container->loadFromExtension('httplug', array(
         'client' => 'my_client',
         'message_factory' => 'my_message_factory',
         'uri_factory' => 'my_uri_factory',
+        'stream_factory' => 'my_stream_factory',
     ),
     'classes' => array(
-        'client' => 'Http\Adapter\Guzzle6HttpAdapter',
-        'message_factory' => 'Http\Discovery\MessageFactory\GuzzleFactory',
-        'uri_factory' => 'Http\Discovery\UriFactory\GuzzleFactory',
+        'client' => 'Http\Adapter\Guzzle6\Client',
+        'message_factory' => 'Http\Message\MessageFactory\GuzzleMessageFactory',
+        'uri_factory' => 'Http\Message\UriFactory\GuzzleUriFactory',
+        'stream_factory' => 'Http\Message\StreamFactory\GuzzleStreamFactory',
     ),
 ));

--- a/Tests/Resources/Fixtures/config/full.xml
+++ b/Tests/Resources/Fixtures/config/full.xml
@@ -6,12 +6,13 @@
             <client>my_client</client>
             <message-factory>my_message_factory</message-factory>
             <uri-factory>my_uri_factory</uri-factory>
+            <stream-factory>my_stream_factory</stream-factory>
         </main-alias>
         <classes>
-            <client>Http\Adapter\Guzzle6HttpAdapter</client>
-            <message-factory>Http\Discovery\MessageFactory\GuzzleFactory</message-factory>
-            <uri-factory>Http\Discovery\UriFactory\GuzzleFactory</uri-factory>
-
+            <client>Http\Adapter\Guzzle6\Client</client>
+            <message-factory>Http\Message\MessageFactory\GuzzleMessageFactory</message-factory>
+            <uri-factory>Http\Message\UriFactory\GuzzleUriFactory</uri-factory>
+            <stream-factory>Http\Message\StreamFactory\GuzzleStreamFactory</stream-factory>
         </classes>
     </config>
 

--- a/Tests/Resources/Fixtures/config/full.yml
+++ b/Tests/Resources/Fixtures/config/full.yml
@@ -3,7 +3,9 @@ httplug:
         client: my_client
         message_factory: my_message_factory
         uri_factory: my_uri_factory
+        stream_factory: my_stream_factory
     classes:
-        client: Http\Adapter\Guzzle6HttpAdapter
-        message_factory: Http\Discovery\MessageFactory\GuzzleFactory
-        uri_factory: Http\Discovery\UriFactory\GuzzleFactory
+        client: Http\Adapter\Guzzle6\Client
+        message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
+        uri_factory: Http\Message\UriFactory\GuzzleUriFactory
+        stream_factory: Http\Message\StreamFactory\GuzzleStreamFactory

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -28,12 +28,15 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'client' => 'httplug.client.default',
                 'message_factory' => 'httplug.message_factory.default',
                 'uri_factory' => 'httplug.uri_factory.default',
+                'stream_factory' => 'httplug.stream_factory.default',
             ),
             'classes' => array(
                 'client' => null,
                 'message_factory' => null,
                 'uri_factory' => null,
+                'stream_factory' => null,
             ),
+            'clients'=>array(),
         );
 
         $formats = array_map(function ($path) {
@@ -56,12 +59,15 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'client' => 'my_client',
                 'message_factory' => 'my_message_factory',
                 'uri_factory' => 'my_uri_factory',
+                'stream_factory' => 'my_stream_factory',
             ),
             'classes' => array(
-                'client' => 'Http\Adapter\Guzzle6HttpAdapter',
-                'message_factory' => 'Http\Discovery\MessageFactory\GuzzleFactory',
-                'uri_factory' => 'Http\Discovery\UriFactory\GuzzleFactory',
+                'client' => 'Http\Adapter\Guzzle6\Client',
+                'message_factory' => 'Http\Message\MessageFactory\GuzzleMessageFactory',
+                'uri_factory' => 'Http\Message\UriFactory\GuzzleUriFactory',
+                'stream_factory' => 'Http\Message\StreamFactory\GuzzleStreamFactory',
             ),
+            'clients'=>array(),
         );
 
         $formats = array_map(function ($path) {

--- a/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -21,30 +21,32 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
     {
         $this->load();
 
-        foreach (['client', 'message_factory', 'uri_factory'] as $type) {
+        foreach (['client', 'message_factory', 'uri_factory', 'stream_factory'] as $type) {
             $this->assertContainerBuilderHasAlias("httplug.$type", "httplug.$type.default");
         }
 
         $this->assertContainerBuilderHasService('httplug.client.default', 'Http\Client\HttpClient');
         $this->assertContainerBuilderHasService('httplug.message_factory.default', 'Http\Message\MessageFactory');
         $this->assertContainerBuilderHasService('httplug.uri_factory.default', 'Http\Message\UriFactory');
+        $this->assertContainerBuilderHasService('httplug.stream_factory.default', 'Http\Message\StreamFactory');
     }
 
     public function testConfigLoadClass()
     {
         $this->load(array(
             'classes' => array(
-                'client' => 'Http\Adapter\Guzzle6HttpAdapter'
+                'client' => 'Http\Adapter\Guzzle6\Client'
             ),
         ));
 
-        foreach (['client', 'message_factory', 'uri_factory'] as $type) {
+        foreach (['client', 'message_factory', 'uri_factory', 'stream_factory'] as $type) {
             $this->assertContainerBuilderHasAlias("httplug.$type", "httplug.$type.default");
         }
 
-        $this->assertContainerBuilderHasService('httplug.client.default', 'Http\Adapter\Guzzle6HttpAdapter');
+        $this->assertContainerBuilderHasService('httplug.client.default', 'Http\Adapter\Guzzle6\Client');
         $this->assertContainerBuilderHasService('httplug.message_factory.default', 'Http\Message\MessageFactory');
         $this->assertContainerBuilderHasService('httplug.uri_factory.default', 'Http\Message\UriFactory');
+        $this->assertContainerBuilderHasService('httplug.stream_factory.default', 'Http\Message\StreamFactory');
     }
 
     public function testConfigLoadService()
@@ -54,15 +56,17 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
                 'client' => 'my_client_service',
                 'message_factory' => 'my_message_factory_service',
                 'uri_factory' => 'my_uri_factory_service',
+                'stream_factory' => 'my_stream_factory_service',
             ),
         ));
 
-        foreach (['client', 'message_factory', 'uri_factory'] as $type) {
+        foreach (['client', 'message_factory', 'uri_factory', 'stream_factory'] as $type) {
             $this->assertContainerBuilderHasAlias("httplug.$type", "my_{$type}_service");
         }
 
         $this->assertContainerBuilderHasService('httplug.client.default', 'Http\Client\HttpClient');
         $this->assertContainerBuilderHasService('httplug.message_factory.default', 'Http\Message\MessageFactory');
         $this->assertContainerBuilderHasService('httplug.uri_factory.default', 'Http\Message\UriFactory');
+        $this->assertContainerBuilderHasService('httplug.stream_factory.default', 'Http\Message\StreamFactory');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,21 +14,30 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php-http/discovery": "^0.2.0",
+        "php": ">=5.5",
+        "php-http/discovery": "^0.6.3",
         "php-http/client-implementation": "^1.0",
-        "php-http/message-factory": "^0.2.0",
+        "php-http/message-factory": "^1.0",
+        "php-http/plugins": "dev-master",
         "symfony/framework-bundle": "^2.7|^3.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.4",
+        "php-http/guzzle6-adapter": "^0.3.1",
+        "php-http/message": "^0.2.1",
+        "php-http/client-common": "^0.1.1",
         "symfony/symfony": "^2.7|^3.0",
-        "php-http/guzzle6-adapter": "^0.2",
         "polishsymfonycommunity/symfony-mocker-container": "~1.0",
-        "matthiasnoback/symfony-dependency-injection-test": "0.*"
+        "matthiasnoback/symfony-dependency-injection-test": "^0.7"
     },
     "autoload": {
         "psr-4": {
             "Http\\HttplugBundle\\": ""
         }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This will implement the feature mentioned in #10. 

This will let the user configure HttpClients for a specific implementation. Everything specific to a client, say guzzle5, is in one class. 

At the moment there is no validation of the special config. We just say: "The config you specify here is sent unparsed to Guzzle". 