### PR TITLE
Make sure we have a default config for the clients variable node

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -104,7 +104,7 @@ class Configuration implements ConfigurationInterface
                         ->info('A list of service ids of plugins. The order is important.')
                         ->prototype('scalar')->end()
                     ->end()
-                    ->variableNode('config')->end()
+                    ->variableNode('config')->defaultValue([])->end()
                 ->end()
             ->end();
     }


### PR DESCRIPTION
If you configure the bundle with: 

```yaml
httplug:
  clients:
    guzzle:
      factory: 'httplug.factory.guzzle6'
```

You would get an undefined array key error because we have no default value for the `config` node. This PR fix that issue. 