### PR TITLE
Add history plugin to the auto discovery client

### DIFF
--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -2,6 +2,7 @@
 
 namespace Http\HttplugBundle\DependencyInjection;
 
+use Http\Client\Plugin\PluginClient;
 use Http\HttplugBundle\ClientFactory\DummyClient;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -88,6 +89,11 @@ class HttplugExtension extends Extension
         // Alias the first client to httplug.client.default
         if ($first !== null) {
             $container->setAlias('httplug.client.default', 'httplug.client.'.$first);
+        } elseif (isset($config['_inject_collector_plugin'])) {
+            // No client was configured. Make sure to inject history plugin to the auto discovery client.
+            $container->register('httplug.client', PluginClient::class)
+                ->addArgument(new Reference('httplug.client.default'))
+                ->addArgument([new Reference('httplug.collector.history_plugin')]);
         }
     }
 }


### PR DESCRIPTION
If you do not configure httplug at all it will use the auto discovery client. That client should also have the history plugin injected if you use the toolbar. 

Im not 100% confident in this PR. We will as always have two identifiers for the default client: `httplug.client` and `httplug.client.default`. This PR makes `httplug.client` a plugin client but not the other. 

Is this okey? The implications would be that you do not see the toolbar when using no configuration and the `httplug.client.default` service id. 