### PR TITLE
Configure plugins

### DIFF
--- a/HttplugBundle.php
+++ b/HttplugBundle.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author David Buchmann <mail@davidbu.ch>
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 class HttplugBundle extends Bundle
 {

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ For information how to write applications with the services provided by this bun
 | httplug.stream_factory | Service* that provides the `Http\Message\StreamFactory`
 | httplug.client.[name] | This is your Httpclient that you have configured. With the configuration below the name would be `acme_client`.
 | httplug.client | This is the first client configured or a client named `default`.
-| httplug.plugin.content_length <br> httplug.plugin.decoder<br> httplug.plugin.error<br> httplug.plugin.logger<br> httplug.plugin.redirect<br> httplug.plugin.retry | These are built in plugins that live in the `php-http/plugins` package. These servcies are not public and may only be used when configure HttpClients or services.
+| httplug.plugin.content_length <br> httplug.plugin.decoder<br> httplug.plugin.error<br> httplug.plugin.logger<br> httplug.plugin.redirect<br> httplug.plugin.retry<br> httplug.plugin.stopwatch | These are plugins that are enabled by default. These services are not public and may only be used when configure HttpClients or other services.
+| httplug.plugin.authentication <br> httplug.plugin.cache<br> httplug.plugin.cookie<br> httplug.plugin.history | These are plugins that are disabled by default. They need to be configured before they can be used. These services are not public and may only be used when configure HttpClients or other services.
 
 \* *These services are always an alias to another service. You can specify your own service or leave the default, which is the same name with `.default` appended. The default services in turn use the service discovery mechanism to provide the best available implementation. You can specify a class for each of the default services to use instead of discovery, as long as those classes can be instantiated without arguments.*
 
@@ -122,10 +123,13 @@ acme_plugin:
 ```yaml
 // config.yml
 httpug:
+    plugins:
+        cache:
+            cache_pool: 'my_cache_pool'
     clients:
         acme:
             factory: 'httplug.factory.guzzle6'
-            plugins: ['acme_plugin' , 'httplug.plugin.logger']
+            plugins: ['acme_plugin', 'httplug.plugin.cache', ''httplug.plugin.retry']
             config:
                 base_uri: 'http://google.se/'
 ```

--- a/Resources/config/plugins.xml
+++ b/Resources/config/plugins.xml
@@ -4,13 +4,31 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="httplug.plugin.authentication" class="Http\Client\Plugin\AuthenticationPlugin" public="false">
+            <argument />
+        </service>
+        <service id="httplug.plugin.cache" class="Http\Client\Plugin\CachePlugin" public="false">
+            <argument />
+            <argument />
+            <argument />
+        </service>
         <service id="httplug.plugin.content_length" class="Http\Client\Plugin\ContentLengthPlugin" public="false" />
+        <service id="httplug.plugin.cookie" class="Http\Client\Plugin\CookiePlugin" public="false">
+            <argument />
+        </service>
         <service id="httplug.plugin.decoder" class="Http\Client\Plugin\DecoderPlugin" public="false" />
         <service id="httplug.plugin.error" class="Http\Client\Plugin\ErrorPlugin" public="false" />
+        <service id="httplug.plugin.history" class="Http\Client\Plugin\HistoryPlugin" public="false">
+            <argument />
+        </service>
         <service id="httplug.plugin.logger" class="Http\Client\Plugin\LoggerPlugin" public="false">
-            <argument type="service" id="logger"/>
+            <argument />
+            <argument>null</argument>
         </service>
         <service id="httplug.plugin.redirect" class="Http\Client\Plugin\RedirectPlugin" public="false" />
         <service id="httplug.plugin.retry" class="Http\Client\Plugin\RetryPlugin" public="false" />
+        <service id="httplug.plugin.stopwatch" class="Http\Client\Plugin\StopwatchPlugin" public="false">
+            <argument />
+        </service>
     </services>
 </container>

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -41,6 +41,47 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'enabled' => 'auto',
                 'formatter' => null,
             ],
+            'plugins' => [
+                'authentication' => [
+                    'enabled' => false,
+                ],
+                'cache' => [
+                    'enabled' => false,
+                    'stream_factory' => 'httplug.stream_factory',
+                    'config' => [
+                        'default_ttl' => null,
+                        'respect_cache_headers' => true,
+                    ],
+                ],
+                'cookie' => [
+                    'enabled' => false,
+                ],
+                'decoder' => [
+                    'enabled' => true,
+                    'use_content_encoding' => true,
+                ],
+                'history' => [
+                    'enabled' => false,
+                ],
+                'logger' => [
+                    'enabled' => true,
+                    'logger' => 'logger',
+                    'formatter' => null,
+                ],
+                'redirect' => [
+                    'enabled' => true,
+                    'preserve_header' => true,
+                    'use_default_for_multiple' => true,
+                ],
+                'retry' => [
+                    'enabled' => true,
+                    'retry' => 1,
+                ],
+                'stopwatch' => [
+                    'enabled' => true,
+                    'stopwatch' => 'debug.stopwatch',
+                ],
+            ],
         ];
 
         $formats = array_map(function ($path) {
@@ -75,6 +116,47 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             'toolbar' => [
                 'enabled' => 'auto',
                 'formatter' => null,
+            ],
+            'plugins' => [
+                'authentication' => [
+                    'enabled' => false,
+                ],
+                'cache' => [
+                    'enabled' => false,
+                    'stream_factory' => 'httplug.stream_factory',
+                    'config' => [
+                        'default_ttl' => null,
+                        'respect_cache_headers' => true,
+                    ],
+                ],
+                'cookie' => [
+                    'enabled' => false,
+                ],
+                'decoder' => [
+                    'enabled' => true,
+                    'use_content_encoding' => true,
+                ],
+                'history' => [
+                    'enabled' => false,
+                ],
+                'logger' => [
+                    'enabled' => true,
+                    'logger' => 'logger',
+                    'formatter' => null,
+                ],
+                'redirect' => [
+                    'enabled' => true,
+                    'preserve_header' => true,
+                    'use_default_for_multiple' => true,
+                ],
+                'retry' => [
+                    'enabled' => true,
+                    'retry' => 1,
+                ],
+                'stopwatch' => [
+                    'enabled' => true,
+                    'stopwatch' => 'debug.stopwatch',
+                ],
             ],
         ];
 


### PR DESCRIPTION
This PR fixes #17 

```yaml
httplug: 
  plugins: 
    cache:
      cache_pool: 'acme.cache'
      config: 
        respect_headers: true
    logger:
      formatter: 'acme.formatter'
```

This make sure that you can configure all our 9 configurable plugins. Some plugins (like `RetryPlugin`) has only optional configuration. They are enabled by default. They others are disabled by default. 

Also, the `LoggerPlugin` is treated special. We inject the `logger` service automatically and it is enabled by default. This is done because of ease of use. 