### PR TITLE
only cache downloaded packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 cache:
     directories:
-        - $HOME/.composer/cache
+        - $HOME/.composer/cache/files
 
 php:
     - 5.5


### PR DESCRIPTION
Caching the entire Composer cache makes Travis to cache Packagist metadata too which are much more likely to make the cache stale too often (while downloaded package archives could still be cached).