### PR TITLE
Make sure travis can run on HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ branches:
 
 matrix:
     fast_finish: true
-    allow_failures:
-        - php: hhvm
     include:
         - php: 5.5
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci" SYMFONY_VERSION=2.7.*

--- a/Tests/Resources/app/AppKernel.php
+++ b/Tests/Resources/app/AppKernel.php
@@ -21,7 +21,11 @@ class AppKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(__DIR__.'/config/config.yml');
+        $runtime = 'php';
+        if (defined('HHVM_VERSION')) {
+            $runtime = 'hhvm';
+        }
+        $loader->load(__DIR__.'/config/config_'.$runtime.'.yml');
     }
 
     /**

--- a/Tests/Resources/app/config/config_hhvm.yml
+++ b/Tests/Resources/app/config/config_hhvm.yml
@@ -1,0 +1,11 @@
+framework:
+  secret: php-http
+  test: ~
+
+# Do not use auto discovery
+httplug:
+  classes:
+    client: Http\Adapter\Guzzle6\Client
+    message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
+    uri_factory: Http\Message\UriFactory\GuzzleUriFactory
+    stream_factory: Http\Message\StreamFactory\GuzzleStreamFactory

--- a/Tests/Resources/app/config/config_php.yml
+++ b/Tests/Resources/app/config/config_php.yml
@@ -2,4 +2,5 @@ framework:
   secret: php-http
   test: ~
 
+# Use auto discovery
 httplug: ~


### PR DESCRIPTION
This PR makes sure to include a different config file for the functional test when running HHVM. The new config file will not use auto discovery. 

This will fix #14 