### PR TITLE
Added Buzz client factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## UNRELEASED
+
+### Added
+
+- Client factories for Buzz.
+
+
 ## 1.0.0 - 2016-03-04
 
 ### Added

--- a/ClientFactory/BuzzFactory.php
+++ b/ClientFactory/BuzzFactory.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Http\HttplugBundle\ClientFactory;
+
+use Buzz\Client\FileGetContents;
+use Http\Adapter\Buzz\Client as Adapter;
+use Http\Message\MessageFactory;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class BuzzFactory implements ClientFactory
+{
+    /**
+     * @var MessageFactory
+     */
+    private $messageFactory;
+
+    /**
+     * @param MessageFactory $messageFactory
+     */
+    public function __construct(MessageFactory $messageFactory)
+    {
+        $this->messageFactory = $messageFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createClient(array $config = [])
+    {
+        if (!class_exists('Http\Adapter\Buzz\Client')) {
+            throw new \LogicException('To use the Buzz adapter you need to install the "php-http/buzz-adapter" package.');
+        }
+
+        $client = new FileGetContents();
+        $options = $this->getOptions($config);
+
+        $client->setTimeout($options['timeout']);
+        $client->setVerifyPeer($options['verify_peer']);
+        $client->setVerifyHost($options['verify_host']);
+        $client->setProxy($options['proxy']);
+
+        return new Adapter($client, $this->messageFactory);
+    }
+
+    /**
+     * Get options to configure the Buzz client.
+     *
+     * @param array $config
+     */
+    private function getOptions(array $config = [])
+    {
+        $resolver = new OptionsResolver();
+
+        $resolver->setDefaults([
+          'timeout' => 5,
+          'verify_peer' => true,
+          'verify_host' => 2,
+          'proxy' => null,
+        ]);
+
+        $resolver->setAllowedTypes('timeout', 'int');
+        $resolver->setAllowedTypes('verify_peer', 'bool');
+        $resolver->setAllowedTypes('verify_host', 'int');
+        $resolver->setAllowedTypes('proxy', ['string', 'null']);
+
+        return $resolver->resolve($config);
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,6 +6,9 @@
     <services>
 
         <!-- ClientFactories -->
+        <service id="httplug.factory.buzz" class="Http\HttplugBundle\ClientFactory\BuzzFactory" public="false">
+            <argument type="service" id="httplug.message_factory"/>
+        </service>
         <service id="httplug.factory.curl" class="Http\HttplugBundle\ClientFactory\CurlFactory" public="false">
             <argument type="service" id="httplug.message_factory"/>
             <argument type="service" id="httplug.stream_factory"/>

--- a/Tests/Unit/ClientFactory/BuzzFactoryTest.php
+++ b/Tests/Unit/ClientFactory/BuzzFactoryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Http\HttplugBundle\Tests\Unit\ClientFactory;
+
+use Http\Adapter\Buzz\Client;
+use Http\HttplugBundle\ClientFactory\BuzzFactory;
+use Http\Message\MessageFactory;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class BuzzFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateClient()
+    {
+        $factory = new BuzzFactory($this->getMock(MessageFactory::class));
+        $client = $factory->createClient();
+
+        $this->assertInstanceOf(Client::class, $client);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "php-http/client-implementation": "^1.0",
         "php-http/message-factory": "^1.0.2",
         "php-http/plugins": "^1.0",
+        "symfony/options-resolver": "^2.7|^3.0",
         "symfony/framework-bundle": "^2.7|^3.0"
     },
     "require-dev": {
@@ -28,6 +29,7 @@
         "php-http/socket-client": "^1.0",
         "php-http/guzzle6-adapter": "^1.0",
         "php-http/react-adapter": "^0.1",
+        "php-http/buzz-adapter": "^0.1",
         "php-http/message": "^1.0",
         "symfony/symfony": "^2.7|^3.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",


### PR DESCRIPTION
I used the option resolver for this factory. That is because the Buzz Client constructor did not accept an array with config. The OptionsResolver lets me avoid lots of `isset($config['foo])`. 