### PR TITLE
Replace plugins package with client-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Guzzle 6 client is now created according to the Httplug specifications with automated minimal behaviour.
   Make sure you configure the Httplug plugins as needed,
   for example if you want to get exceptions for failure HTTP status codes.
+- **[BC] PluginClientFactory returns an instance of `Http\Client\Common\PluginClient`** (see [php-http/client-common#14](https://github.com/php-http/client-common/pull/14))
+- Plugins are loaded from their new packages, fall back to `php-http/plugins` if necessary
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   Make sure you configure the Httplug plugins as needed,
   for example if you want to get exceptions for failure HTTP status codes.
 - **[BC] PluginClientFactory returns an instance of `Http\Client\Common\PluginClient`** (see [php-http/client-common#14](https://github.com/php-http/client-common/pull/14))
-- Plugins are loaded from their new packages, fall back to `php-http/plugins` if necessary
+- Plugins are loaded from their new packages
 
 
 ### Fixed

--- a/ClientFactory/PluginClientFactory.php
+++ b/ClientFactory/PluginClientFactory.php
@@ -2,8 +2,8 @@
 
 namespace Http\HttplugBundle\ClientFactory;
 
-use Http\Client\Plugin\Plugin;
-use Http\Client\Plugin\PluginClient;
+use Http\Client\Common\Plugin;
+use Http\Client\Common\PluginClient;
 
 /**
  * This factory creates a PluginClient.

--- a/Collector/MessageJournal.php
+++ b/Collector/MessageJournal.php
@@ -3,7 +3,7 @@
 namespace Http\HttplugBundle\Collector;
 
 use Http\Client\Exception;
-use Http\Client\Plugin\Journal;
+use Http\Client\Common\Plugin\Journal;
 use Http\Message\Formatter;
 use Http\Message\Formatter\SimpleFormatter;
 use Psr\Http\Message\RequestInterface;

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -3,9 +3,6 @@
 namespace Http\HttplugBundle\DependencyInjection;
 
 use Http\Client\Common\Plugin\AuthenticationPlugin;
-use Http\Client\Common\Plugin\CachePlugin;
-use Http\Client\Common\Plugin\LoggerPlugin;
-use Http\Client\Common\Plugin\StopwatchPlugin;
 use Http\Client\Common\PluginClient;
 use Http\HttplugBundle\ClientFactory\DummyClient;
 use Http\Message\Authentication\BasicAuth;
@@ -141,10 +138,6 @@ class HttplugExtension extends Extension
     {
         switch ($name) {
             case 'cache':
-                // To preserve BC, we check the existence of the new plugin class and use it if available
-                if (class_exists(CachePlugin::class)) {
-                    $definition->setClass(CachePlugin::class);
-                }
                 $definition
                     ->replaceArgument(0, new Reference($config['cache_pool']))
                     ->replaceArgument(1, new Reference($config['stream_factory']))
@@ -160,10 +153,6 @@ class HttplugExtension extends Extension
                 $definition->replaceArgument(0, new Reference($config['journal']));
                 break;
             case 'logger':
-                // To preserve BC, we check the existence of the new plugin class and use it if available
-                if (class_exists(LoggerPlugin::class)) {
-                    $definition->setClass(LoggerPlugin::class);
-                }
                 $definition->replaceArgument(0, new Reference($config['logger']));
                 if (!empty($config['formatter'])) {
                     $definition->replaceArgument(1, new Reference($config['formatter']));
@@ -178,10 +167,6 @@ class HttplugExtension extends Extension
                 $definition->addArgument($config['retry']);
                 break;
             case 'stopwatch':
-                // To preserve BC, we check the existence of the new plugin class and use it if available
-                if (class_exists(StopwatchPlugin::class)) {
-                    $definition->setClass(StopwatchPlugin::class);
-                }
                 $definition->replaceArgument(0, new Reference($config['stopwatch']));
                 break;
         }

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -2,8 +2,11 @@
 
 namespace Http\HttplugBundle\DependencyInjection;
 
-use Http\Client\Plugin\AuthenticationPlugin;
-use Http\Client\Plugin\PluginClient;
+use Http\Client\Common\Plugin\AuthenticationPlugin;
+use Http\Client\Common\Plugin\CachePlugin;
+use Http\Client\Common\Plugin\LoggerPlugin;
+use Http\Client\Common\Plugin\StopwatchPlugin;
+use Http\Client\Common\PluginClient;
 use Http\HttplugBundle\ClientFactory\DummyClient;
 use Http\Message\Authentication\BasicAuth;
 use Http\Message\Authentication\Bearer;
@@ -119,6 +122,7 @@ class HttplugExtension extends Extension
 
         foreach ($config as $name => $pluginConfig) {
             $pluginId = 'httplug.plugin.'.$name;
+
             if ($pluginConfig['enabled']) {
                 $def = $container->getDefinition($pluginId);
                 $this->configurePluginByName($name, $def, $pluginConfig);
@@ -137,6 +141,10 @@ class HttplugExtension extends Extension
     {
         switch ($name) {
             case 'cache':
+                // To preserve BC, we check the existence of the new plugin class and use it if available
+                if (class_exists(CachePlugin::class)) {
+                    $definition->setClass(CachePlugin::class);
+                }
                 $definition
                     ->replaceArgument(0, new Reference($config['cache_pool']))
                     ->replaceArgument(1, new Reference($config['stream_factory']))
@@ -152,6 +160,10 @@ class HttplugExtension extends Extension
                 $definition->replaceArgument(0, new Reference($config['journal']));
                 break;
             case 'logger':
+                // To preserve BC, we check the existence of the new plugin class and use it if available
+                if (class_exists(LoggerPlugin::class)) {
+                    $definition->setClass(LoggerPlugin::class);
+                }
                 $definition->replaceArgument(0, new Reference($config['logger']));
                 if (!empty($config['formatter'])) {
                     $definition->replaceArgument(1, new Reference($config['formatter']));
@@ -166,6 +178,10 @@ class HttplugExtension extends Extension
                 $definition->addArgument($config['retry']);
                 break;
             case 'stopwatch':
+                // To preserve BC, we check the existence of the new plugin class and use it if available
+                if (class_exists(StopwatchPlugin::class)) {
+                    $definition->setClass(StopwatchPlugin::class);
+                }
                 $definition->replaceArgument(0, new Reference($config['stopwatch']));
                 break;
         }

--- a/Resources/config/data-collector.xml
+++ b/Resources/config/data-collector.xml
@@ -10,7 +10,7 @@
             <argument>null</argument>
         </service>
 
-        <service id="httplug.collector.history_plugin" class="Http\Client\Plugin\HistoryPlugin" public="false">
+        <service id="httplug.collector.history_plugin" class="Http\Client\Common\Plugin\HistoryPlugin" public="false">
             <argument type="service" id="httplug.collector.message_journal"/>
         </service>
     </services>

--- a/Resources/config/plugins.xml
+++ b/Resources/config/plugins.xml
@@ -9,21 +9,21 @@
             <argument />
             <argument />
         </service>
-        <service id="httplug.plugin.content_length" class="Http\Client\Plugin\ContentLengthPlugin" public="false" />
-        <service id="httplug.plugin.cookie" class="Http\Client\Plugin\CookiePlugin" public="false">
+        <service id="httplug.plugin.content_length" class="Http\Client\Common\Plugin\ContentLengthPlugin" public="false" />
+        <service id="httplug.plugin.cookie" class="Http\Client\Common\Plugin\CookiePlugin" public="false">
             <argument />
         </service>
-        <service id="httplug.plugin.decoder" class="Http\Client\Plugin\DecoderPlugin" public="false" />
-        <service id="httplug.plugin.error" class="Http\Client\Plugin\ErrorPlugin" public="false" />
-        <service id="httplug.plugin.history" class="Http\Client\Plugin\HistoryPlugin" public="false">
+        <service id="httplug.plugin.decoder" class="Http\Client\Common\Plugin\DecoderPlugin" public="false" />
+        <service id="httplug.plugin.error" class="Http\Client\Common\Plugin\ErrorPlugin" public="false" />
+        <service id="httplug.plugin.history" class="Http\Client\Common\Plugin\HistoryPlugin" public="false">
             <argument />
         </service>
         <service id="httplug.plugin.logger" class="Http\Client\Plugin\LoggerPlugin" public="false">
             <argument />
             <argument>null</argument>
         </service>
-        <service id="httplug.plugin.redirect" class="Http\Client\Plugin\RedirectPlugin" public="false" />
-        <service id="httplug.plugin.retry" class="Http\Client\Plugin\RetryPlugin" public="false" />
+        <service id="httplug.plugin.redirect" class="Http\Client\Common\Plugin\RedirectPlugin" public="false" />
+        <service id="httplug.plugin.retry" class="Http\Client\Common\Plugin\RetryPlugin" public="false" />
         <service id="httplug.plugin.stopwatch" class="Http\Client\Plugin\StopwatchPlugin" public="false">
             <argument />
         </service>

--- a/Resources/config/plugins.xml
+++ b/Resources/config/plugins.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="httplug.plugin.cache" class="Http\Client\Plugin\CachePlugin" public="false">
+        <service id="httplug.plugin.cache" class="Http\Client\Common\Plugin\CachePlugin" public="false">
             <argument />
             <argument />
             <argument />
@@ -18,13 +18,13 @@
         <service id="httplug.plugin.history" class="Http\Client\Common\Plugin\HistoryPlugin" public="false">
             <argument />
         </service>
-        <service id="httplug.plugin.logger" class="Http\Client\Plugin\LoggerPlugin" public="false">
+        <service id="httplug.plugin.logger" class="Http\Client\Common\Plugin\LoggerPlugin" public="false">
             <argument />
             <argument>null</argument>
         </service>
         <service id="httplug.plugin.redirect" class="Http\Client\Common\Plugin\RedirectPlugin" public="false" />
         <service id="httplug.plugin.retry" class="Http\Client\Common\Plugin\RetryPlugin" public="false" />
-        <service id="httplug.plugin.stopwatch" class="Http\Client\Plugin\StopwatchPlugin" public="false">
+        <service id="httplug.plugin.stopwatch" class="Http\Client\Common\Plugin\StopwatchPlugin" public="false">
             <argument />
         </service>
     </services>

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
         "php-http/client-implementation": "^1.0",
         "php-http/message-factory": "^1.0.2",
         "php-http/client-common": "^1.1",
-        "php-http/plugins": "^1.1",
+        "php-http/cache-plugin": "^1.0",
+        "php-http/logger-plugin": "^1.0",
+        "php-http/stopwatch-plugin": "^1.0",
         "symfony/options-resolver": "^2.7|^3.0",
         "symfony/framework-bundle": "^2.7|^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php": ">=5.5",
         "php-http/client-implementation": "^1.0",
         "php-http/message-factory": "^1.0.2",
-        "php-http/plugins": "^1.0",
+        "php-http/client-common": "^1.1",
+        "php-http/plugins": "^1.1",
         "symfony/options-resolver": "^2.7|^3.0",
         "symfony/framework-bundle": "^2.7|^3.0"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | yes
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

Replaces php-http/plugins with php-http/common-client.


#### Why?

The plugins package has been deprecated and moved to client-common.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
