### PR TITLE
Do not run travis on dev-* branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
 branches:
     except:
         - /^analysis-.*$/
+        - /^dev-.*$/
 
 matrix:
     fast_finish: true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

The `dev-*` branches are used for development and are most likely to end up in a PR.