### PR TITLE
Move the exception symbol one step up in the stack

### DIFF
--- a/Resources/views/webprofiler.html.twig
+++ b/Resources/views/webprofiler.html.twig
@@ -117,7 +117,7 @@
                     <tr class="httplug-request-stack">
                         <td class="httplug-plugin-name">&darr; {{ pluginNames[idx-1] }} </td>
                         <td class="httplug-plugin-name">&uarr;
-                            {% if failureStack[idx] %}
+                            {% if failureStack[idx-1] %}
                                 <span class="httplug-error">&#9747;</span>
                             {% endif %}
                         </td>
@@ -130,7 +130,11 @@
                 {% if loop.last %}
                     <tr class="httplug-request-stack">
                         <td class="httplug-plugin-name">&#10230; <span class="push-right">HTTP client</span></td>
-                        <td class="httplug-plugin-name">&uarr;</td>
+                        <td class="httplug-plugin-name">&uarr;
+                            {% if failureStack[idx-1] %}
+                                <span class="httplug-error">&#9747;</span>
+                            {% endif %}
+                        </td>
                     </tr>
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | https://github.com/php-http/documentation/pull/118
| License         | MIT

While making screenshots for the documentation I noticed that the exception symbol was misplaced. Consider the screenshot below. 

When an exception is thrown at the error plugin we should have the big red X next to it. Before this PR the symbol appeared first at the content_length plugin. 

![error-plugin-failure](https://cloud.githubusercontent.com/assets/1275206/16923513/f2131af4-4d1a-11e6-84eb-4acedaa0965d.png)
