### PR TITLE
Fix debug tool registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 
+## 1.2.2 - 2016-07-19
+
+### Fixed
+
+- Do not register debug tools when debugging is disabled (eg. in prod mode)
+
+
 ## 1.2.1 - 2016-07-19
 
 ### Fixed


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

Fixes the bundle in production mode.


#### Why?

In production mode (and when debug mode is disabled) debug tools should not be registered in the clients, otherwise we get weird service not found errors.
