### PR TITLE
Add support for default_host and force_host options on each client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 
 ### Added
 
+- Option to configure default host for each client. default_host to add host if missing, force_host to change all requests to a specific host.
 - Support for BatchClient
-- The stopwatch plugin in included by default when using profiling. 
+- The stopwatch plugin in included by default when using profiling.
 
 ### Changed
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -92,6 +92,7 @@ class Configuration implements ConfigurationInterface
                     return $v;
                 })
             ->end()
+            ->fixXmlConfig('client')
             ->children()
                 ->arrayNode('main_alias')
                     ->addDefaultsIfNotSet()
@@ -184,6 +185,22 @@ class Configuration implements ConfigurationInterface
                         ->defaultFalse()
                         ->info('Set to true to get the client wrapped in a BatchClient which allows you to send multiple request at the same time.')
                     ->end()
+                    ->arrayNode('options')
+                        ->validate()
+                            ->ifTrue(function ($options) {
+                                return array_key_exists('default_host', $options) && array_key_exists('force_host', $options);
+                            })
+                            ->thenInvalid('You can only set one of default_host and force_host for each client')
+                        ->end()
+                        ->children()
+                            ->scalarNode('default_host')
+                                ->info('Configure the AddHostPlugin for this client. Add host if request is only for a path.')
+                            ->end()
+                            ->scalarNode('force_host')
+                                ->info('Configure the AddHostPlugin for this client. Send all requests to this host regardless of host in request.')
+                            ->end()
+                        ->end()
+                    ->end()
                     ->arrayNode('plugins')
                         ->info('A list of service ids of plugins. The order is important.')
                         ->prototype('scalar')->end()
@@ -202,7 +219,7 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('plugins')
                 ->addDefaultsIfNotSet()
                 ->children()
-                    ->append($this->addAuthenticationPluiginNode())
+                    ->append($this->addAuthenticationPluginNode())
 
                     ->arrayNode('cache')
                     ->canBeEnabled()
@@ -313,7 +330,7 @@ class Configuration implements ConfigurationInterface
      *
      * @return ArrayNodeDefinition|\Symfony\Component\Config\Definition\Builder\NodeDefinition
      */
-    private function addAuthenticationPluiginNode()
+    private function addAuthenticationPluginNode()
     {
         $builder = new TreeBuilder();
         $node = $builder->root('authentication');

--- a/Tests/Resources/Fixtures/config/full.php
+++ b/Tests/Resources/Fixtures/config/full.php
@@ -13,6 +13,15 @@ $container->loadFromExtension('httplug', [
         'uri_factory'     => 'Http\Message\UriFactory\GuzzleUriFactory',
         'stream_factory'  => 'Http\Message\StreamFactory\GuzzleStreamFactory',
     ],
+    'clients' => [
+        'test' => [
+            'factory' => 'httplug.factory.guzzle6',
+            'http_methods_client' => true,
+            'options' => [
+                'default_host' => 'http://localhost',
+            ],
+        ],
+    ],
     'profiling' => [
         'enabled' => true,
         'formatter' => 'my_toolbar_formatter',

--- a/Tests/Resources/Fixtures/config/full.xml
+++ b/Tests/Resources/Fixtures/config/full.xml
@@ -14,6 +14,9 @@
             <uri-factory>Http\Message\UriFactory\GuzzleUriFactory</uri-factory>
             <stream-factory>Http\Message\StreamFactory\GuzzleStreamFactory</stream-factory>
         </classes>
+        <client name="test" factory="httplug.factory.guzzle6" http-methods-client="true">
+            <options default-host="http://localhost"/>
+        </client>
         <profiling enabled="true" formatter="my_toolbar_formatter" captured_body_length="0"/>
         <plugins>
             <authentication>

--- a/Tests/Resources/Fixtures/config/full.yml
+++ b/Tests/Resources/Fixtures/config/full.yml
@@ -9,6 +9,12 @@ httplug:
         message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
         uri_factory: Http\Message\UriFactory\GuzzleUriFactory
         stream_factory: Http\Message\StreamFactory\GuzzleStreamFactory
+    clients:
+        test:
+            factory: httplug.factory.guzzle6
+            http_methods_client: true
+            options:
+                default_host: http://localhost
     profiling:
         enabled: true
         formatter: my_toolbar_formatter

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -115,7 +115,19 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'uri_factory' => 'Http\Message\UriFactory\GuzzleUriFactory',
                 'stream_factory' => 'Http\Message\StreamFactory\GuzzleStreamFactory',
             ],
-            'clients' => [],
+            'clients' => [
+                'test' => [
+                    'factory' => 'httplug.factory.guzzle6',
+                    'http_methods_client' => true,
+                    'flexible_client' => false,
+                    'batch_client' => false,
+                    'options' => [
+                        'default_host' => 'http://localhost',
+                    ],
+                    'plugins' => [],
+                    'config' => [],
+                ],
+            ],
             'profiling' => [
                 'enabled' => true,
                 'formatter' => 'my_toolbar_formatter',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #110
| Documentation   | TODO (want feedback first)
| License         | MIT


#### What's in this PR?

Add new configuration options for default_host and force_host for each client.


#### Why?

See #110


#### Example Usage

``` yaml
    clients:
        test:
            factory: httplug.factory.guzzle6
            http_methods_client: true
            options:
                default_host: http://localhost
```

You can specify the httplug.client.{name}.default|force_host_plugin in the plugins list if you dont want the host plugin to come last in the chain.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
