### PR TITLE
Allow to configure plugins specifically for a client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Added
 
+- You can now also configure client specific plugins in the `plugins` option of a client.
+  Some plugins that you previously had to define in your own services can now be configured on the client.
 - Support for BatchClient
 - The stopwatch plugin in included by default when using profiling.
 

--- a/Resources/config/plugins.xml
+++ b/Resources/config/plugins.xml
@@ -27,5 +27,25 @@
         <service id="httplug.plugin.stopwatch" class="Http\Client\Common\Plugin\StopwatchPlugin" public="false">
             <argument />
         </service>
+
+        <!-- client specific plugin definition prototypes -->
+
+        <service id="httplug.plugin.add_host" class="Http\Client\Common\Plugin\AddHostPlugin" public="false" abstract="true">
+            <argument/>
+            <argument/>
+        </service>
+        <service id="httplug.plugin.header_append" class="Http\Client\Common\Plugin\HeaderAppendPlugin" public="false" abstract="true">
+            <argument/>
+        </service>
+        <service id="httplug.plugin.header_defaults" class="Http\Client\Common\Plugin\HeaderDefaultsPlugin" public="false" abstract="true">
+            <argument/>
+        </service>
+        <service id="httplug.plugin.header_set" class="Http\Client\Common\Plugin\HeaderSetPlugin" public="false" abstract="true">
+            <argument/>
+        </service>
+        <service id="httplug.plugin.header_remove" class="Http\Client\Common\Plugin\HeaderRemovePlugin" public="false" abstract="true">
+            <argument/>
+        </service>
+
     </services>
 </container>

--- a/Tests/Functional/ServiceInstantiationTest.php
+++ b/Tests/Functional/ServiceInstantiationTest.php
@@ -43,7 +43,10 @@ class ServiceInstantiationTest extends WebTestCase
         $plugins = $journal->getPlugins('acme');
         $this->assertEquals([
             'httplug.plugin.stopwatch',
+            'httplug.client.acme.plugin.decoder',
             'httplug.plugin.redirect',
+            'httplug.client.acme.plugin.add_host',
+            'httplug.client.acme.authentication.my_basic',
         ], $plugins);
     }
 }

--- a/Tests/Resources/Fixtures/config/full.php
+++ b/Tests/Resources/Fixtures/config/full.php
@@ -13,6 +13,43 @@ $container->loadFromExtension('httplug', [
         'uri_factory'     => 'Http\Message\UriFactory\GuzzleUriFactory',
         'stream_factory'  => 'Http\Message\StreamFactory\GuzzleStreamFactory',
     ],
+    'clients' => [
+        'test' => [
+            'factory' => 'httplug.factory.guzzle6',
+            'http_methods_client' => true,
+            'plugins' => [
+                'httplug.plugin.redirect',
+                [
+                    'add_host' => [
+                        'host' => 'http://localhost',
+                    ],
+                ],
+                [
+                    'header_set' => [
+                        'headers' => [
+                            'X-FOO' => 'bar',
+                        ],
+                    ],
+                ],
+                [
+                    'header_remove' => [
+                        'headers' => [
+                            'X-FOO',
+                        ],
+                    ],
+                ],
+                [
+                    'authentication' => [
+                        'my_basic' => [
+                            'type' => 'basic',
+                            'username' => 'foo',
+                            'password' => 'bar',
+                        ],
+                    ],
+                ]
+            ],
+        ],
+    ],
     'profiling' => [
         'enabled' => true,
         'formatter' => 'my_toolbar_formatter',

--- a/Tests/Resources/Fixtures/config/full.xml
+++ b/Tests/Resources/Fixtures/config/full.xml
@@ -14,6 +14,27 @@
             <uri-factory>Http\Message\UriFactory\GuzzleUriFactory</uri-factory>
             <stream-factory>Http\Message\StreamFactory\GuzzleStreamFactory</stream-factory>
         </classes>
+        <client name="test" factory="httplug.factory.guzzle6" http-methods-client="true">
+            <plugin>httplug.plugin.redirect</plugin>
+            <plugin>
+                <add-host host="http://localhost"/>
+            </plugin>
+            <plugin>
+                <header-set>
+                    <header name="X-FOO">bar</header>
+                </header-set>
+            </plugin>
+            <plugin>
+                <header-remove>
+                    <header>X-FOO</header>
+                </header-remove>
+            </plugin>
+            <plugin>
+                <authentication>
+                    <my_basic type="basic" username="foo" password="bar"/>
+                </authentication>
+            </plugin>
+        </client>
         <profiling enabled="true" formatter="my_toolbar_formatter" captured_body_length="0"/>
         <plugins>
             <authentication>

--- a/Tests/Resources/Fixtures/config/full.yml
+++ b/Tests/Resources/Fixtures/config/full.yml
@@ -9,6 +9,28 @@ httplug:
         message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
         uri_factory: Http\Message\UriFactory\GuzzleUriFactory
         stream_factory: Http\Message\StreamFactory\GuzzleStreamFactory
+    clients:
+        test:
+            factory: httplug.factory.guzzle6
+            http_methods_client: true
+            plugins:
+                - 'httplug.plugin.redirect'
+                -
+                    add_host:
+                        host: http://localhost
+                -
+                    header_set:
+                        headers:
+                            X-FOO: bar
+                -
+                    header_remove:
+                        headers: [X-FOO]
+                -
+                    authentication:
+                        my_basic:
+                            type: basic
+                            username: foo
+                            password: bar
     profiling:
         enabled: true
         formatter: my_toolbar_formatter

--- a/Tests/Resources/Fixtures/config/invalid_plugin.yml
+++ b/Tests/Resources/Fixtures/config/invalid_plugin.yml
@@ -1,0 +1,6 @@
+httplug:
+    clients:
+        acme:
+            plugins:
+                - foobar:
+                    baz: ~

--- a/Tests/Resources/app/config/config.yml
+++ b/Tests/Resources/app/config/config.yml
@@ -7,4 +7,16 @@ httplug:
         acme:
             factory: httplug.factory.curl
             plugins:
+                -
+                    decoder:
+                        use_content_encoding: false
                 - httplug.plugin.redirect
+                -
+                    add_host:
+                        host: "http://localhost:8000"
+                -
+                    authentication:
+                        my_basic:
+                            type: basic
+                            username: foo
+                            password: bar

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -115,7 +115,55 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'uri_factory' => 'Http\Message\UriFactory\GuzzleUriFactory',
                 'stream_factory' => 'Http\Message\StreamFactory\GuzzleStreamFactory',
             ],
-            'clients' => [],
+            'clients' => [
+                'test' => [
+                    'factory' => 'httplug.factory.guzzle6',
+                    'http_methods_client' => true,
+                    'flexible_client' => false,
+                    'batch_client' => false,
+                    'plugins' => [
+                        [
+                            'reference' => [
+                                'enabled' => true,
+                                'id' => 'httplug.plugin.redirect',
+                            ],
+                        ],
+                        [
+                            'add_host' => [
+                                'enabled' => true,
+                                'host' => 'http://localhost',
+                                'replace' => false,
+                            ],
+                        ],
+                        [
+                            'header_set' => [
+                                'enabled' => true,
+                                'headers' => [
+                                    'X-FOO' => 'bar',
+                                ],
+                            ],
+                        ],
+                        [
+                            'header_remove' => [
+                                'enabled' => true,
+                                'headers' => [
+                                    'X-FOO',
+                                ],
+                            ],
+                        ],
+                        [
+                            'authentication' => [
+                                'my_basic' => [
+                                    'type' => 'basic',
+                                    'username' => 'foo',
+                                    'password' => 'bar',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'config' => [],
+                ],
+            ],
             'profiling' => [
                 'enabled' => true,
                 'formatter' => 'my_toolbar_formatter',
@@ -208,6 +256,16 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
     public function testMissingClass()
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/invalid_class.yml';
+        $this->assertProcessedConfigurationEquals([], [$file]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Unrecognized option "foobar" under "httplug.clients.acme.plugins.0"
+     */
+    public function testInvalidPlugin()
+    {
+        $file = __DIR__.'/../../Resources/Fixtures/config/invalid_plugin.yml';
         $this->assertProcessedConfigurationEquals([], [$file]);
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #110
| Documentation   | https://github.com/php-http/documentation/pull/142
| License         | MIT


#### What's in this PR?

Add new configuration for plugins specifically to a client. The global plugin configuration is duplicated to allow configuring all plugins with client specific information.

#### Why?

See #110


#### Example Usage

``` yaml
httplug:
    plugins:
        logger:
            enabled: true
            logger: 'logger'
            formatter: null
        redirect:
            enabled: true
            preserve_header: true
            use_default_for_multiple: true
        retry:
            enabled: true
            retry: 1
    clients:
        todo:
            factory: "httplug.factory.guzzle6"
            plugins:
                - 'httplug.plugin.logger'
                - 'httplug.plugin.redirect'
                -  add_host:
                     host: http://localhost
                - 'httplug.plugin.retry'
        acme:
            factory: 'httplug.factory.guzzle6'
            plugins: ['httplug.plugin.redirect', 'httplug.plugin.retry']
```

You can specify the httplug.client.{name}.plugin.add_host in the plugins list if you want the host plugin to come somewhere else than last in the chain.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Add the other plugins we currently dont support (want feedback first)
  - [x] HeaderSet
  - [x] HeaderRemove
  - [x] HeaderDefaults 
  - [x] HeaderAppend
  - [x] -ContentLength- (configured as shared plugin, has no options)
- [x] Handle custom authentication plugin
- [x] Fix XML configuration
- [x] Documentation pull request created => https://github.com/php-http/documentation/pull/142
