### PR TITLE
DummyClient should implement HttpClient, HttpAsyncClient

### DIFF
--- a/ClientFactory/DummyClient.php
+++ b/ClientFactory/DummyClient.php
@@ -2,11 +2,22 @@
 
 namespace Http\HttplugBundle\ClientFactory;
 
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use Psr\Http\Message\RequestInterface;
+
 /**
  * This client is used as a placeholder for the dependency injection. It will never be used.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class DummyClient
+class DummyClient implements HttpClient, HttpAsyncClient
 {
+    public function sendAsyncRequest(RequestInterface $request)
+    {
+    }
+
+    public function sendRequest(RequestInterface $request)
+    {
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | not sure
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

Some IDEs use Symfony container for static analysis and code autocomplete. But DummyClient does not provide any methods. Because of this, IDE shows errors:

![IDE shows error](http://www.picshare.ru/uploads/160912/758KYpoWSc.jpg)

This PR adds to `DummyClient` dummy implementation of `HttpClient` and `HttpAsyncClient` to fix IDE behavior.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

