### PR TITLE
Add information about client installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Via Composer
 ``` bash
 $ composer require php-http/httplug-bundle
 ```
-Make sure to also require at least one client (eg: [guzzle6-adapter](https://github.com/php-http/guzzle6-adapter) or [curl](https://github.com/php-http/curl-client)).
+Make sure to also require at least one [client](http://docs.php-http.org/en/latest/clients.html).
 
 Enable the bundle in your kernel:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Via Composer
 ``` bash
 $ composer require php-http/httplug-bundle
 ```
+Make sure to also require at least one client (eg: [guzzle6-adapter](https://github.com/php-http/guzzle6-adapter) or [curl](https://github.com/php-http/curl-client)).
 
 Enable the bundle in your kernel:
 


### PR DESCRIPTION
`php-http/client-implementation` makes sure we install a client otherwise composer installation fails.