### PR TITLE
Stop running tests for symfony 3.0 which is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
     global:
         - TEST_COMMAND="composer test"
     matrix:
+        - SYMFONY_VERSION=3.2.*
         - SYMFONY_VERSION=3.1.*
-        - SYMFONY_VERSION=3.0.*
         - SYMFONY_VERSION=2.8.*
         - SYMFONY_VERSION=2.7.*
 


### PR DESCRIPTION
Stop testing the bundle against symfony/symfony 3.0 which is EOL and incompatible with twig/twig 2.x.

I also added symfony/symfony 3.2 in the matrix :)

Related symfony issue: https://github.com/symfony/symfony/issues/20284