### PR TITLE
show profiler badges in the toolbar and the menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The profiler collector has been rewritten to use objects instead of arrays.
 - Bumped minimum Symfony version to 2.8.
+- Updated profiler badges to match Symfony 2.8+ profiler design.
 
 ### Fixed
 

--- a/Resources/views/webprofiler.html.twig
+++ b/Resources/views/webprofiler.html.twig
@@ -13,15 +13,15 @@
         {% set text %}
             <div class="sf-toolbar-info-piece">
                 <b>Successful requests</b>
-                <span>{{ collector.successfulStacks|length }}</span>
+                <span class="sf-toolbar-status">{{ collector.successfulStacks|length }}</span>
             </div>
             <div class="sf-toolbar-info-piece">
                 <b>Failed requests</b>
-                <span>{{ collector.failedStacks|length }}</span>
+                <span class="sf-toolbar-status {{ collector.failedStacks|length ? 'sf-toolbar-status-red' }}">{{ collector.failedStacks|length }}</span>
             </div>
         {% endset %}
 
-        {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+        {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url, 'status': collector.failedStacks|length ? 'red' : '' } %}
     {% endif %}
 {% endblock %}
 
@@ -33,11 +33,16 @@
 
 {% block menu %}
     {# This left-hand menu appears when using the full-screen profiler. #}
-    <span class="label {{ collector.stacks|length == 0 ? 'disabled' }}">
+    <span class="label {{ collector.stacks|length == 0 ? 'disabled' }} {{ collector.failedStacks|length ? 'label-status-error' }}">
         <span class="icon">
             {{ include('@Httplug/Icon/httplug.svg') }}
         </span>
         <strong>Httplug</strong>
+        {% if collector.failedStacks|length %}
+            <span class="count">
+                <span>{{ collector.failedStacks|length }}</span>
+            </span>
+        {% endif %}
     </span>
 {% endblock %}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #93 
| Documentation   | N/A
| License         | MIT

This PR add profiler badges introduced with Symfony 2.8 profiler redesign.

- The toolbar icon is now displayed wit ha red background if there was errors.
![toolbar_failed_no_hover](https://cloud.githubusercontent.com/assets/1116116/23164707/d6b55384-f838-11e6-8287-ba241274f911.png)

- The toolbar hover add squared badges to display numbers.
![toolbar_successful](https://cloud.githubusercontent.com/assets/1116116/23164708/d6b62c46-f838-11e6-82ab-b32bfc24bf25.png)

- The failed request count badge is show using red background if a request failed.
![toolbar_failed](https://cloud.githubusercontent.com/assets/1116116/23164709/d6b68a7e-f838-11e6-9e62-e4abd7d1241b.png)

- The profiler menu show the failed request count
![profiler_menu](https://cloud.githubusercontent.com/assets/1116116/23164742/01a8ce7c-f839-11e6-85fe-76cbaf7f780b.png)
