### PR TITLE
Make sure we always have a stack

### DIFF
--- a/Collector/Collector.php
+++ b/Collector/Collector.php
@@ -62,7 +62,7 @@ class Collector extends DataCollector
     }
 
     /**
-     * @return Stack
+     * @return Stack|boolean false if no current stack.
      */
     public function getCurrentStack()
     {

--- a/Collector/Collector.php
+++ b/Collector/Collector.php
@@ -62,7 +62,7 @@ class Collector extends DataCollector
     }
 
     /**
-     * @return Stack|boolean false if no current stack.
+     * @return Stack|bool false if no current stack.
      */
     public function getCurrentStack()
     {

--- a/Collector/ProfilePlugin.php
+++ b/Collector/ProfilePlugin.php
@@ -58,7 +58,9 @@ class ProfilePlugin implements Plugin
     {
         $profile = new Profile($this->pluginName, $this->formatter->formatRequest($request));
 
-        $this->collector->getCurrentStack()->addProfile($profile);
+        if (false !== $stack = $this->collector->getCurrentStack()) {
+            $stack->addProfile($profile);
+        }
 
         return $this->plugin->handleRequest($request, $next, $first)->then(function (ResponseInterface $response) use ($profile) {
             $profile->setResponse($this->formatter->formatResponse($response));

--- a/Collector/ProfilePlugin.php
+++ b/Collector/ProfilePlugin.php
@@ -58,7 +58,7 @@ class ProfilePlugin implements Plugin
     {
         $profile = new Profile($this->pluginName, $this->formatter->formatRequest($request));
 
-        if (false !== $stack = $this->collector->getCurrentStack()) {
+        if ($stack = $this->collector->getCurrentStack()) {
             $stack->addProfile($profile);
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #133
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

If we (for some reason) do not have a stack, it should not crash. Just pretend everything is normal. 

@dkvk, does this patch solve your issue?
