### PR TITLE
add profile client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+- The real request method and target url are now displayed in the profiler.
+
 ## 1.4.0 - 2017-02-21
 
 ### Changed

--- a/Collector/ProfileClient.php
+++ b/Collector/ProfileClient.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Http\HttplugBundle\Collector;
+
+use Http\Client\Common\FlexibleHttpClient;
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * The ProfileClient decorates any client that implement both HttpClient and HttpAsyncClient interfaces to gather target
+ * url and response status code.
+ *
+ * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ *
+ * @internal
+ */
+class ProfileClient implements HttpClient, HttpAsyncClient
+{
+    /**
+     * @var HttpClient|HttpAsyncClient
+     */
+    private $client;
+
+    /**
+     * @var Collector
+     */
+    private $collector;
+
+    /**
+     * @param HttpClient|HttpAsyncClient $client    The client to profile. Client must implement both HttpClient and
+     *                                              HttpAsyncClient interfaces.
+     * @param Collector                  $collector
+     */
+    public function __construct($client, Collector $collector)
+    {
+        if (!($client instanceof HttpClient && $client instanceof HttpAsyncClient)) {
+            throw new \RuntimeException(sprintf(
+                '%s first argument must implement %s and %s. Consider using %s.',
+                    __METHOD__,
+                    HttpClient::class,
+                    HttpAsyncClient::class,
+                    FlexibleHttpClient::class
+            ));
+        }
+        $this->client = $client;
+        $this->collector = $collector;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendAsyncRequest(RequestInterface $request)
+    {
+        $this->collectRequestInformations($request);
+
+        return $this->client->sendAsyncRequest($request);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendRequest(RequestInterface $request)
+    {
+        $this->collectRequestInformations($request);
+
+        return $this->client->sendRequest($request);
+    }
+
+    /**
+     * @param RequestInterface $request
+     */
+    private function collectRequestInformations(RequestInterface $request)
+    {
+        if (!$stack = $this->collector->getCurrentStack()) {
+            return;
+        }
+
+        $stack = $this->collector->getCurrentStack();
+        $stack->setRequestTarget($request->getRequestTarget());
+        $stack->setRequestMethod($request->getMethod());
+    }
+}

--- a/Collector/ProfileClientFactory.php
+++ b/Collector/ProfileClientFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Http\HttplugBundle\Collector;
+
+use Http\Client\Common\FlexibleHttpClient;
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use Http\HttplugBundle\ClientFactory\ClientFactory;
+
+/**
+ * The ProfileClientFactory decorates any ClientFactory and returns the created client decorated by a ProfileClient.
+ *
+ * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ *
+ * @internal
+ */
+class ProfileClientFactory implements ClientFactory
+{
+    /**
+     * @var ClientFactory|callable
+     */
+    private $factory;
+
+    /**
+     * @var Collector
+     */
+    private $collector;
+
+    /**
+     * @param ClientFactory|callable $factory
+     * @param Collector              $collector
+     */
+    public function __construct($factory, Collector $collector)
+    {
+        if (!$factory instanceof ClientFactory && !is_callable($factory)) {
+            throw new \RuntimeException(sprintf('First argument to ProfileClientFactory::__construct must be a "%s" or a callable.', ClientFactory::class));
+        }
+        $this->factory = $factory;
+        $this->collector = $collector;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createClient(array $config = [])
+    {
+        $client = is_callable($this->factory) ? $this->factory($config) : $this->factory->createClient($config);
+
+        if (!($client instanceof HttpClient && $client instanceof HttpAsyncClient)) {
+            $client = new FlexibleHttpClient($client);
+        }
+
+        return new ProfileClient($client, $this->collector);
+    }
+}

--- a/Collector/Stack.php
+++ b/Collector/Stack.php
@@ -37,6 +37,16 @@ final class Stack
     private $failed = false;
 
     /**
+     * @var string
+     */
+    private $requestTarget;
+
+    /**
+     * @var string
+     */
+    private $requestMethod;
+
+    /**
      * @param string $client
      * @param string $request
      */
@@ -108,5 +118,37 @@ final class Stack
     public function setFailed($failed)
     {
         $this->failed = $failed;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequestTarget()
+    {
+        return $this->requestTarget;
+    }
+
+    /**
+     * @param string $requestTarget
+     */
+    public function setRequestTarget($requestTarget)
+    {
+        $this->requestTarget = $requestTarget;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequestMethod()
+    {
+        return $this->requestMethod;
+    }
+
+    /**
+     * @param string $requestMethod
+     */
+    public function setRequestMethod($requestMethod)
+    {
+        $this->requestMethod = $requestMethod;
     }
 }

--- a/Resources/config/data-collector.xml
+++ b/Resources/config/data-collector.xml
@@ -29,5 +29,31 @@
         <service id="httplug.collector.twig.http_message" class="Http\HttplugBundle\Collector\Twig\HttpMessageMarkupExtension" public="false">
             <tag name="twig.extension" />
         </service>
+
+        <!-- ClientFactories -->
+        <service id="httplug.collector.factory.buzz" class="Http\HttplugBundle\Collector\ProfileClientFactory" decorates="httplug.factory.buzz" public="false">
+            <argument type="service" id="httplug.collector.factory.buzz.inner"/>
+            <argument type="service" id="httplug.collector.collector"/>
+        </service>
+        <service id="httplug.collector.factory.curl" class="Http\HttplugBundle\Collector\ProfileClientFactory" decorates="httplug.factory.curl" public="false">
+            <argument type="service" id="httplug.collector.factory.curl.inner"/>
+            <argument type="service" id="httplug.collector.collector"/>
+        </service>
+        <service id="httplug.collector.factory.guzzle5" class="Http\HttplugBundle\Collector\ProfileClientFactory" decorates="httplug.factory.guzzle5" public="false">
+            <argument type="service" id="httplug.collector.factory.guzzle5.inner"/>
+            <argument type="service" id="httplug.collector.collector"/>
+        </service>
+        <service id="httplug.collector.factory.guzzle6" class="Http\HttplugBundle\Collector\ProfileClientFactory" decorates="httplug.factory.guzzle6" public="false">
+            <argument type="service" id="httplug.collector.factory.guzzle6.inner"/>
+            <argument type="service" id="httplug.collector.collector"/>
+        </service>
+        <service id="httplug.collector.factory.react" class="Http\HttplugBundle\Collector\ProfileClientFactory" decorates="httplug.factory.react" public="false">
+            <argument type="service" id="httplug.collector.factory.react.inner"/>
+            <argument type="service" id="httplug.collector.collector"/>
+        </service>
+        <service id="httplug.collector.factory.socket" class="Http\HttplugBundle\Collector\ProfileClientFactory" decorates="httplug.factory.socket" public="false">
+            <argument type="service" id="httplug.collector.factory.socket.inner"/>
+            <argument type="service" id="httplug.collector.collector"/>
+        </service>
     </services>
 </container>

--- a/Resources/views/webprofiler.html.twig
+++ b/Resources/views/webprofiler.html.twig
@@ -62,7 +62,7 @@
 
                 {% for stack in collector.clientStacks(client) %}
                     <h3>
-                        Request #{{ loop.index }}
+                        Request #{{ loop.index }} - {{ stack.requestMethod }} {{ stack.requestTarget }}
                         {% if stack.failed %}
                             - <span class="httplug-error">Errored</span>
                         {% endif %}

--- a/Tests/Unit/Collector/ProfileClientTest.php
+++ b/Tests/Unit/Collector/ProfileClientTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Http\HttplugBundle\Tests\Unit\Collector;
+
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use Http\HttplugBundle\Collector\Collector;
+use Http\HttplugBundle\Collector\ProfileClient;
+use Http\HttplugBundle\Collector\Stack;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class ProfileClientTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Collector
+     */
+    private $collector;
+
+    /**
+     * @var Stack
+     */
+    private $currentStack;
+
+    /**
+     * @var HttpClient
+     */
+    private $client;
+
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+
+    /**
+     * @var ProfileClient
+     */
+    private $subject;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    /**
+     * @var Promise
+     */
+    private $promise;
+
+    public function setUp()
+    {
+        $this->collector = $this->getMockBuilder(Collector::class)->disableOriginalConstructor()->getMock();
+        $this->currentStack = new Stack('default', 'FormattedRequest');
+        $this->client = $this->getMockBuilder(ClientInterface::class)->getMock();
+        $this->request = $this->getMockBuilder(RequestInterface::class)->getMock();
+        $this->subject = new ProfileClient($this->client, $this->collector);
+        $this->response = $this->getMockBuilder(ResponseInterface::class)->getMock();
+        $this->promise = $this->getMockBuilder(Promise::class)->getMock();
+
+        $this->client->method('sendRequest')->willReturn($this->response);
+        $this->client->method('sendAsyncRequest')->willReturn($this->promise);
+
+        $this->request->method('getMethod')->willReturn('GET');
+        $this->request->method('getRequestTarget')->willReturn('/target');
+
+        $this->collector->method('getCurrentStack')->willReturn($this->currentStack);
+    }
+
+    public function testCallDecoratedClient()
+    {
+        $this->client
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->identicalTo($this->request))
+        ;
+
+        $this->client
+            ->expects($this->once())
+            ->method('sendAsyncRequest')
+            ->with($this->identicalTo($this->request))
+        ;
+
+        $this->assertEquals($this->response, $this->subject->sendRequest($this->request));
+
+        $this->assertEquals($this->promise, $this->subject->sendAsyncRequest($this->request));
+    }
+
+    public function testCollectRequestInformations()
+    {
+        $this->subject->sendRequest($this->request);
+
+        $this->assertEquals('GET', $this->currentStack->getRequestMethod());
+        $this->assertEquals('/target', $this->currentStack->getRequestTarget());
+    }
+
+    public function testCollectAsyncRequestInformations()
+    {
+        $this->subject->sendAsyncRequest($this->request);
+
+        $this->assertEquals('GET', $this->currentStack->getRequestMethod());
+        $this->assertEquals('/target', $this->currentStack->getRequestTarget());
+    }
+}
+
+interface ClientInterface extends HttpClient, HttpAsyncClient
+{
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Partially #108, Partially #93, Partially #135 
| Documentation   | N/A
| License         | MIT

#### What's in this PR?

This add tracking of request target url and method. I choose to decorate the Client at the lowest possible level (i.e not the PluginClient, but the inner one) to be able to catch what goes in and out the Client and avoid false informations because of the registered plugins.

Technically, when the profiling is enabled, each client factory is decorated with a `ProfileClientFactory` which returns the original client decorated with a `ProfileClient`.

This is what I suggested for #135 


#### Why?

Those new collected informations are required to write a better profiler.

#### To Do

- [x] Unit tests
- [x] Update changelog