### PR TITLE
Fix access to private static properties

### DIFF
--- a/Discovery/ConfiguredClientsStrategy.php
+++ b/Discovery/ConfiguredClientsStrategy.php
@@ -35,8 +35,8 @@ class ConfiguredClientsStrategy implements DiscoveryStrategy, EventSubscriberInt
      */
     public function __construct(HttpClient $httpClient = null, HttpAsyncClient $asyncClient = null)
     {
-        static::$client = $httpClient;
-        static::$asyncClient = $asyncClient;
+        self::$client = $httpClient;
+        self::$asyncClient = $asyncClient;
     }
 
     /**
@@ -44,15 +44,15 @@ class ConfiguredClientsStrategy implements DiscoveryStrategy, EventSubscriberInt
      */
     public static function getCandidates($type)
     {
-        if ($type === HttpClient::class && static::$client !== null) {
+        if ($type === HttpClient::class && self::$client !== null) {
             return [['class' => function () {
-                return static::$client;
+                return self::$client;
             }]];
         }
 
-        if ($type === HttpAsyncClient::class && static::$asyncClient !== null) {
+        if ($type === HttpAsyncClient::class && self::$asyncClient !== null) {
             return [['class' => function () {
-                return static::$asyncClient;
+                return self::$asyncClient;
             }]];
         }
 


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a

#### Why?

Using late static binding to access private static properties is wrong, as child classes are not allowed to access them. This would lead to a fatal error when using a child class.
