### PR TITLE
Fix the validation of incompatible options

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -155,19 +155,16 @@ class Configuration implements ConfigurationInterface
     {
         $root->children()
             ->arrayNode('clients')
-                ->validate()
-                    ->ifTrue(function ($clients) {
-                        foreach ($clients as $name => $config) {
-                            // Make sure we only allow one of these to be true
-                            return (bool) $config['flexible_client'] + (bool) $config['http_methods_client'] + (bool) $config['batch_client'] >= 2;
-                        }
-
-                        return false;
-                    })
-                    ->thenInvalid('A http client can\'t be decorated with both FlexibleHttpClient and HttpMethodsClient. Only one of the following options can be true. ("flexible_client", "http_methods_client")')->end()
                 ->useAttributeAsKey('name')
                 ->prototype('array')
                 ->fixXmlConfig('plugin')
+                ->validate()
+                    ->ifTrue(function ($config) {
+                        // Make sure we only allow one of these to be true
+                        return (bool) $config['flexible_client'] + (bool) $config['http_methods_client'] + (bool) $config['batch_client'] >= 2;
+                    })
+                    ->thenInvalid('A http client can\'t be decorated with both FlexibleHttpClient and HttpMethodsClient. Only one of the following options can be true. ("flexible_client", "http_methods_client", "batch_client")')
+                ->end()
                 ->children()
                     ->scalarNode('factory')
                         ->isRequired()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | not really
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT


All clients must be validated, not only the first one (which was the case due to returning during the first iteration of the loop over clients).
The easiest way to handle it is to put the validation inside the prototype node, so that each client is validated separately. This also allows to have a better error message (as the error message will tell you which client is invalid as the error will be inside the client configuration node).
The error message is also fixed to talk about the third incompatible features.

I answered `not really` for BC breaks, because there is a small change. If someone configures incompatible features in a client other than the first one, the DI configuration layer was not rejecting it previously.
But this is not a huge issue, because configuring both would not work properly today anyway (which is why features are marked as incompatible), as they would only get access to features of the last one (as other ones would be hidden inside the decorator stack)