### PR TITLE
Fix the message about incompatible features

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -163,7 +163,7 @@ class Configuration implements ConfigurationInterface
                         // Make sure we only allow one of these to be true
                         return (bool) $config['flexible_client'] + (bool) $config['http_methods_client'] + (bool) $config['batch_client'] >= 2;
                     })
-                    ->thenInvalid('A http client can\'t be decorated with both FlexibleHttpClient and HttpMethodsClient. Only one of the following options can be true. ("flexible_client", "http_methods_client", "batch_client")')
+                    ->thenInvalid('A http client can\'t be decorated with several of FlexibleHttpClient, HttpMethodsClient and BatchClient. Only one of the following options can be true. ("flexible_client", "http_methods_client", "batch_client")')
                 ->end()
                 ->children()
                     ->scalarNode('factory')


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT

The validation actually covers 3 incompatible messages, not 2 of them. My previous PR fixing the validation for clients added the name of the third option in the error message when I saw that it was missing, but I forgot to update the first sentence.