### PR TITLE
Avoid registering the strategy listener when it is useless

### DIFF
--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -411,6 +411,12 @@ class HttplugExtension extends Extension
             $asyncHttpClient = new Reference($asyncHttpClient);
         }
 
+        if (null === $httpClient && null === $asyncHttpClient) {
+            $container->removeDefinition('httplug.strategy');
+
+            return;
+        }
+
         $container
             ->getDefinition('httplug.strategy')
             ->addArgument($httpClient)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT


If both the client and the async client are null, the strategy would never find any candidates. In such case, it is useless to register it as a `kernel.request` listener to prepend itself to the discovery, as it would not have any effect on the discovery, but it requires work on each request.