### PR TITLE
Enable autowiring support for symfony 3.3+

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,6 +8,9 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <!-- enable autowiring compatibility in Symfony 3.3+ -->
+        <service id="Http\Client\HttpClient" alias="httplug.client" public="false" />
+
         <!-- ClientFactories -->
         <service id="httplug.factory.buzz" class="Http\HttplugBundle\ClientFactory\BuzzFactory" public="false">
             <argument type="service" id="httplug.message_factory"/>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

This configure the ``httplug.client`` as being the right choice for autowiring in Symfony 3.3+ when being asked to autowire a ``Http\Client\HttpClient`` typehint.
This also adds autowiring for all the message factory interfaces, using the main aliases as target.


#### Why?

Autowiring is one of the nice features of Symfony 3.3+ (working autowiring actually. We already have autowiring since 2.8 but it was not working well). So it is great to support it out of the box, especially when it has no impact for people using older versions or not using autowiring (the private alias just gets removed during the container optimizations anyway).

Autowiring support cannot be enabled for Symfony 2.8 to 3.1 for people using multiple clients because resolving ambiguities cannot be done by targeting an alias in these versions. Projects using a single client *may* experience a working autowiring in this case. But enabling the discovery in `auto` mode (which is the case by default) creates a second client, and using any decorator client (`flexible_client`, `http_methods_client` or `batch_client` features) also involves creating additional services implementing the interface, so it is quite unlikely to work fine for them (and there is nothing we can do about except migrating to Symfony 3.3 to have the improved autowiring as fixing this case is one of the main improvements).
We could do hacks to have this autowiring working in *some* cases, but the code would be quite ugly and would still have many cases where it would create WTF behaviors instead of the expected one. So I preferred not to support autowiring out of the box in Symfony < 3.3 instead.