### PR TITLE
Replace deprecated calls to getMock in unit tests

### DIFF
--- a/Tests/Unit/ClientFactory/BuzzFactoryTest.php
+++ b/Tests/Unit/ClientFactory/BuzzFactoryTest.php
@@ -13,7 +13,7 @@ class BuzzFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreateClient()
     {
-        $factory = new BuzzFactory($this->getMock(MessageFactory::class));
+        $factory = new BuzzFactory($this->getMockBuilder(MessageFactory::class)->getMock());
         $client = $factory->createClient();
 
         $this->assertInstanceOf(Client::class, $client);

--- a/Tests/Unit/ClientFactory/CurlFactoryTest.php
+++ b/Tests/Unit/ClientFactory/CurlFactoryTest.php
@@ -14,7 +14,10 @@ class CurlFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreateClient()
     {
-        $factory = new CurlFactory($this->getMock(MessageFactory::class), $this->getMock(StreamFactory::class));
+        $factory = new CurlFactory(
+            $this->getMockBuilder(MessageFactory::class)->getMock(),
+            $this->getMockBuilder(StreamFactory::class)->getMock()
+        );
         $client = $factory->createClient();
 
         $this->assertInstanceOf(Client::class, $client);

--- a/Tests/Unit/ClientFactory/ReactFactoryTest.php
+++ b/Tests/Unit/ClientFactory/ReactFactoryTest.php
@@ -13,7 +13,7 @@ class ReactFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreateClient()
     {
-        $factory = new ReactFactory($this->getMock(MessageFactory::class));
+        $factory = new ReactFactory($this->getMockBuilder(MessageFactory::class)->getMock());
         $client = $factory->createClient();
 
         $this->assertInstanceOf(Client::class, $client);

--- a/Tests/Unit/ClientFactory/SocketFactoryTest.php
+++ b/Tests/Unit/ClientFactory/SocketFactoryTest.php
@@ -13,7 +13,7 @@ class SocketFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreateClient()
     {
-        $factory = new SocketFactory($this->getMock(MessageFactory::class));
+        $factory = new SocketFactory($this->getMockBuilder(MessageFactory::class)->getMock());
         $client = $factory->createClient();
 
         $this->assertInstanceOf(Client::class, $client);

--- a/Tests/Unit/Discovery/ConfiguredClientsStrategyTest.php
+++ b/Tests/Unit/Discovery/ConfiguredClientsStrategyTest.php
@@ -10,8 +10,8 @@ class ConfiguredClientsStrategyTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetCandidates()
     {
-        $httpClient = $this->getMock(HttpClient::class);
-        $httpAsyncClient = $this->getMock(HttpAsyncClient::class);
+        $httpClient = $this->getMockBuilder(HttpClient::class)->getMock();
+        $httpAsyncClient = $this->getMockBuilder(HttpAsyncClient::class)->getMock();
         $strategy = new ConfiguredClientsStrategy($httpClient, $httpAsyncClient);
 
         $candidates = $strategy::getCandidates(HttpClient::class);
@@ -36,7 +36,7 @@ class ConfiguredClientsStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCandidatesEmptyAsync()
     {
-        $httpClient = $this->getMock(HttpClient::class);
+        $httpClient = $this->getMockBuilder(HttpClient::class)->getMock();
         $strategy = new ConfiguredClientsStrategy($httpClient, null);
 
         $candidates = $strategy::getCandidates(HttpClient::class);
@@ -49,7 +49,7 @@ class ConfiguredClientsStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCandidatesEmptySync()
     {
-        $httpAsyncClient = $this->getMock(HttpAsyncClient::class);
+        $httpAsyncClient = $this->getMockBuilder(HttpAsyncClient::class)->getMock();
         $strategy = new ConfiguredClientsStrategy(null, $httpAsyncClient);
 
         $candidates = $strategy::getCandidates(HttpClient::class);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A| Documentation   | N/A
| License         | MIT

I'm bored to see all those deprecated calls while running phpunit!
