### PR TITLE
Fix ProfileClient creation with callable factory

### DIFF
--- a/Collector/ProfileClientFactory.php
+++ b/Collector/ProfileClientFactory.php
@@ -51,7 +51,7 @@ class ProfileClientFactory implements ClientFactory
      */
     public function createClient(array $config = [])
     {
-        $client = is_callable($this->factory) ? $this->factory($config) : $this->factory->createClient($config);
+        $client = is_callable($this->factory) ? call_user_func($this->factory, $config) : $this->factory->createClient($config);
 
         if (!($client instanceof HttpClient && $client instanceof HttpAsyncClient)) {
             $client = new FlexibleHttpClient($client);

--- a/Tests/Unit/Collector/ProfileClientFactoryTest.php
+++ b/Tests/Unit/Collector/ProfileClientFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Http\HttplugBundle\Tests\Unit\Collector;
+
+use Http\Client\HttpClient;
+use Http\HttplugBundle\ClientFactory\ClientFactory;
+use Http\HttplugBundle\Collector\Collector;
+use Http\HttplugBundle\Collector\Formatter;
+use Http\HttplugBundle\Collector\ProfileClient;
+use Http\HttplugBundle\Collector\ProfileClientFactory;
+
+class ProfileClientFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Collector
+     */
+    private $collector;
+
+    /**
+     * @var Formatter
+     */
+    private $formatter;
+
+    /**
+     * @var HttpClient
+     */
+    private $client;
+
+    public function setUp()
+    {
+        $this->collector = $this->getMockBuilder(Collector::class)->disableOriginalConstructor()->getMock();
+        $this->formatter = $this->getMockBuilder(Formatter::class)->disableOriginalConstructor()->getMock();
+        $this->client = $this->getMockBuilder(HttpClient::class)->getMock();
+    }
+
+    public function testCreateClientFromClientFactory()
+    {
+        $factory = $this->getMockBuilder(ClientFactory::class)->getMock();
+        $factory->method('createClient')->willReturn($this->client);
+
+        $subject = new ProfileClientFactory($factory, $this->collector, $this->formatter);
+
+        $this->assertInstanceOf(ProfileClient::class, $subject->createClient());
+    }
+
+    public function testCreateClientFromCallable()
+    {
+        $factory = function ($config) {
+            return $this->client;
+        };
+
+        $subject = new ProfileClientFactory($factory, $this->collector, $this->formatter);
+
+        $this->assertInstanceOf(ProfileClient::class, $subject->createClient());
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | N/A
| License         | MIT

The ProfileClientFactory added in #136 was not tested and contained an error while decorating a callable factory. This is now fixed with tests.
