### PR TITLE
Fix broken profiling.formatter option

### DIFF
--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -63,7 +63,7 @@ class HttplugExtension extends Extension
             if (!empty($config['profiling']['formatter'])) {
                 // Add custom formatter
                 $container
-                    ->getDefinition('httplug.collector.debug_collector')
+                    ->getDefinition('httplug.collector.formatter')
                     ->replaceArgument(0, new Reference($config['profiling']['formatter']))
                 ;
             }

--- a/Resources/config/data-collector.xml
+++ b/Resources/config/data-collector.xml
@@ -12,11 +12,6 @@
             <argument type="service" id="httplug.formatter.full_http_message"/>
         </service>
 
-        <service id="httplug.collector.debug_collector" class="Http\HttplugBundle\Collector\DebugPluginCollector" public="false">
-            <argument type="service" id="httplug.formatter.full_http_message"/>
-            <argument type="service" id="httplug.collector.plugin_journal"/>
-        </service>
-
         <service id="httplug.collector.collector" class="Http\HttplugBundle\Collector\Collector" public="false">
             <tag name="data_collector" template="HttplugBundle::webprofiler.html.twig" priority="200" id="httplug"/>
         </service>

--- a/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -197,6 +197,20 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         $this->assertTrue(isset($arguments[3]));
     }
 
+    public function testOverrideProfillingFormatter()
+    {
+        $this->load(
+            [
+                'profiling' => [
+                    'formatter' => 'acme.formatter',
+                ],
+            ]
+        );
+
+        $def = $this->container->findDefinition('httplug.collector.formatter');
+        $this->assertEquals('acme.formatter', (string) $def->getArgument(0));
+    }
+
     private function verifyProfilingDisabled()
     {
         $def = $this->container->findDefinition('httplug.client');


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | N/A
| License         | MIT

Since #128, the `profiling.formatter` option is broken. So there is the fix with a unit test.