### PR TITLE
Display discovered clients in the profiler

### DIFF
--- a/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -116,7 +116,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         ]);
 
         $plugins = [
-            'httplug.client.acme.plugin.newstack',
+            'httplug.client.acme.plugin.stack',
             'httplug.plugin.stopwatch',
             'httplug.client.acme.plugin.decoder',
             'httplug.plugin.redirect',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #133 
| Documentation   | N/A
| License         | MIT

## Content

Auto discovered clients were not visible in the profiler. This behavior is broken since at least 1.3. I didn't test any further back to find when it was broken.

This also fixes the root cause of #133. The easier way to test it is with `knplabs/github-api`.

The bug root cause was caused by the stopwatch plugin which was shared between every clients. When a client was configured, the stopwatch plugin gets decorated with the `ProfilePlugin` and when executed, no stack plugin was executed before.

## About plugins state

So we have a plugin instance per client. I don't know if it's a good or a bad thing but we probably have to be clear on what to do. I think its ok to share a plugin if it is stateless, but if the plugin is stateful it should not be shared at all (like the StackPlugin which hold the client name).

I think we should choose a way to go, shared plugins or no shared plugins. Doing the choice will probably allow us to do some refactoring in the bundle container extension, which looks like really complicated to met.

Ping @Nyholm @sagikazarmark @dbu 