### PR TITLE
expand configuration definition and adjust tests, closes #151

### DIFF
--- a/Tests/Resources/Fixtures/config/full.php
+++ b/Tests/Resources/Fixtures/config/full.php
@@ -80,8 +80,12 @@ $container->loadFromExtension('httplug', [
             'cache_pool' => 'my_cache_pool',
             'stream_factory' => 'my_other_stream_factory',
             'config' => [
+                'cache_lifetime' => 2592000,
                 'default_ttl' => 42,
-                'respect_response_cache_directives' => ['X-Foo', 'X-Bar'],
+                'hash_algo' => 'sha1',
+                'methods' => ['GET'],
+                'cache_key_generator' => null,
+                'respect_response_cache_directives' => ['X-Foo'],
             ],
         ],
         'cookie' => [

--- a/Tests/Resources/Fixtures/config/full.xml
+++ b/Tests/Resources/Fixtures/config/full.xml
@@ -44,9 +44,9 @@
                 <my_service type="service" service="my_auth_service"/>
             </authentication>
             <cache cache-pool="my_cache_pool" stream-factory="my_other_stream_factory">
-                <config default-ttl="42">
-                    <respect-response-cache-directives>X-Foo</respect-response-cache-directives>
-                    <respect-response-cache-directives>X-Bar</respect-response-cache-directives>
+                <config default-ttl="42" cache-lifetime="2592000" hash-algo="sha1" cache-key-generator="null">
+                    <respect-response-cache-directive>X-Foo</respect-response-cache-directive>
+                    <method>GET</method>
                 </config>
             </cache>
             <cookie cookie-jar="my_cookie_jar"/>

--- a/Tests/Resources/Fixtures/config/full.yml
+++ b/Tests/Resources/Fixtures/config/full.yml
@@ -55,10 +55,14 @@ httplug:
             cache_pool: my_cache_pool
             stream_factory: my_other_stream_factory
             config:
+                cache_lifetime: 2592000
                 default_ttl: 42
+                hash_algo: sha1
+                methods:
+                  - GET
+                cache_key_generator: null
                 respect_response_cache_directives:
                   - X-Foo
-                  - X-Bar
         cookie:
             cookie_jar: my_cookie_jar
         decoder:

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -36,7 +36,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'enabled' => false,
                 'stream_factory' => 'httplug.stream_factory',
                 'config' => [
-                    'default_ttl' => 0,
+                    'methods' => ['GET', 'HEAD'],
                 ],
             ],
             'cookie' => [
@@ -194,8 +194,12 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'cache_pool' => 'my_cache_pool',
                     'stream_factory' => 'my_other_stream_factory',
                     'config' => [
+                        'cache_lifetime' => 2592000,
                         'default_ttl' => 42,
-                        'respect_response_cache_directives' => ['X-Foo', 'X-Bar'],
+                        'hash_algo' => 'sha1',
+                        'methods' => ['GET'],
+                        'cache_key_generator' => null,
+                        'respect_response_cache_directives' => ['X-Foo'],
                     ],
                 ],
                 'cookie' => [
@@ -317,7 +321,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             'enabled' => true,
             'cache_pool' => 'my_cache_pool',
             'config' => [
-                'default_ttl' => 0,
+                'methods' => ['GET', 'HEAD'],
                 'respect_cache_headers' => true,
             ],
         ]);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #151
| License         | MIT

I would like to point out that the official documentation at http://docs.php-http.org/en/latest/plugins/cache.html does not mention the `hash_algo` configuration option.