### PR TITLE
Display stack duration in profiler

### DIFF
--- a/Resources/public/style/httplug.css
+++ b/Resources/public/style/httplug.css
@@ -80,6 +80,11 @@
     font-size: 12px;
 }
 
+.httplug-duration {
+    min-width: 6ch;
+    text-align:center;
+}
+
 /**
  * HTTP method colors from swagger-ui.
  */

--- a/Resources/views/webprofiler.html.twig
+++ b/Resources/views/webprofiler.html.twig
@@ -94,6 +94,7 @@
                             <span class="httplug-target">{{ stack.requestTarget }}</span>
                         </div>
                         <div>
+                            <span class="label httplug-duration">{{ stack.duration|number_format }} ms</span>
                             {% if stack.responseCode >= 400 and stack.responseCode <= 599 %}
                                 <span class="label status-error">{{ stack.responseCode }}</span>
                             {% elseif stack.responseCode >= 300 and stack.responseCode <= 399 %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #156 
| Documentation   | N/A
| License         | MIT

This add the stack duration in the profiler.

![httplugbundle4](https://cloud.githubusercontent.com/assets/1116116/25614452/42ad36c6-2f32-11e7-8ebe-17993bf69ca6.png)
