### PR TITLE
Add copy as curl button in profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The real request method and target url are now displayed in the profiler.
 - Support the cache plugin configuration for `respect_response_cache_directives`.
 - Extended WebProfilerToolbar item to list request with details.
+- You can now copy any request as cURL command in the profiler.
 
 ### Changed
 

--- a/Collector/Formatter.php
+++ b/Collector/Formatter.php
@@ -6,11 +6,13 @@ use Exception;
 use Http\Client\Exception\HttpException;
 use Http\Client\Exception\TransferException;
 use Http\Message\Formatter as MessageFormatter;
+use Http\Message\Formatter\CurlCommandFormatter;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * This class is a decorator for any Http\Message\Formatter with the the ability to format exceptions.
+ * This class is a decorator for any Http\Message\Formatter with the the ability to format exceptions and requests as
+ * cURL commands.
  *
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  *
@@ -24,11 +26,18 @@ class Formatter implements MessageFormatter
     private $formatter;
 
     /**
-     * @param MessageFormatter $formatter
+     * @var CurlCommandFormatter
      */
-    public function __construct(MessageFormatter $formatter)
+    private $curlFormatter;
+
+    /**
+     * @param MessageFormatter     $formatter
+     * @param CurlCommandFormatter $curlFormatter
+     */
+    public function __construct(MessageFormatter $formatter, CurlCommandFormatter $curlFormatter)
     {
         $this->formatter = $formatter;
+        $this->curlFormatter = $curlFormatter;
     }
 
     /**
@@ -65,5 +74,17 @@ class Formatter implements MessageFormatter
     public function formatResponse(ResponseInterface $response)
     {
         return $this->formatter->formatResponse($response);
+    }
+
+    /**
+     * Format a RequestInterface as a cURL command.
+     *
+     * @param RequestInterface $request
+     *
+     * @return string
+     */
+    public function formatAsCurlCommand(RequestInterface $request)
+    {
+        return $this->curlFormatter->formatRequest($request);
     }
 }

--- a/Collector/ProfileClient.php
+++ b/Collector/ProfileClient.php
@@ -133,6 +133,7 @@ class ProfileClient implements HttpClient, HttpAsyncClient
         $stack->setRequestScheme($request->getUri()->getScheme());
         $stack->setRequestHost($request->getUri()->getHost());
         $stack->setClientRequest($this->formatter->formatRequest($request));
+        $stack->setCurlCommand($this->formatter->formatAsCurlCommand($request));
     }
 
     /**

--- a/Collector/Stack.php
+++ b/Collector/Stack.php
@@ -82,6 +82,11 @@ final class Stack
     private $duration = 0;
 
     /**
+     * @var string
+     */
+    private $curlCommand;
+
+    /**
      * @param string $client
      * @param string $request
      */
@@ -297,5 +302,21 @@ final class Stack
     public function setDuration($duration)
     {
         $this->duration = $duration;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurlCommand()
+    {
+        return $this->curlCommand;
+    }
+
+    /**
+     * @param string $curlCommand
+     */
+    public function setCurlCommand($curlCommand)
+    {
+        $this->curlCommand = $curlCommand;
     }
 }

--- a/Resources/config/data-collector.xml
+++ b/Resources/config/data-collector.xml
@@ -10,6 +10,9 @@
 
         <service id="httplug.collector.formatter" class="Http\HttplugBundle\Collector\Formatter" public="false">
             <argument type="service" id="httplug.formatter.full_http_message"/>
+            <argument type="service">
+                <service class="Http\Message\Formatter\CurlCommandFormatter" />
+            </argument>
         </service>
 
         <service id="httplug.collector.collector" class="Http\HttplugBundle\Collector\Collector" public="false">

--- a/Resources/public/script/httplug.js
+++ b/Resources/public/script/httplug.js
@@ -10,3 +10,18 @@ document.addEventListener("DOMContentLoaded", function() {
         });
     });
 });
+
+/**
+ * Copy as cURL.
+ */
+document.addEventListener("DOMContentLoaded", function () {
+    Array.prototype.forEach.call(document.getElementsByClassName('httplug-toolbar'), function (toolbar) {
+        var button = toolbar.querySelector('.httplug-copy-as-curl>button');
+        button.addEventListener('click', function() {
+            var input = toolbar.querySelector('.httplug-copy-as-curl>input');
+            input.select();
+            document.execCommand('copy');
+            input.setSelectionRange(0, 0);
+       });
+    });
+})

--- a/Resources/public/style/httplug.css
+++ b/Resources/public/style/httplug.css
@@ -20,6 +20,46 @@
     text-align: center;
 }
 
+/**
+ * Toolbar
+ */
+.httplug-toolbar {
+    display: flex;
+    justify-content: space-between;
+}
+
+.httplug-toolbar>*:not(:last-child) {
+    margin-right:5px;
+}
+
+.httplug-toolbar .httplug-copy-as-curl {
+    flex: 1;
+}
+
+.httplug-copy-as-curl {
+    font-size: 0; /*hide line return spacings*/
+    display: flex;
+}
+
+.httplug-copy-as-curl>input {
+    padding: .5em .75em;
+    border-radius: 2px 0px 0px 2px;
+    border: 0;
+    line-height: inherit;
+    background-color: #eee;
+    opacity: 1;
+    font-size: 14px;
+    flex: 1;
+}
+
+.httplug-copy-as-curl>button {
+    font-size: 14px;
+    border-radius: 0px 2px 2px 0px;
+}
+
+/**
+ * Message
+ */
 .httplug-message {
     box-sizing: border-box;
     padding: 5px;
@@ -30,6 +70,14 @@
     white-space: nowrap;
 }
 
+.httplug-messages {
+    clear: both;
+    display: flex;
+}
+
+/**
+ * Stack header
+ */
 .httplug-stack-header {
     display: flex;
     justify-content: space-between;
@@ -57,11 +105,6 @@
     background: white;
     color: black;
     font-size: 0; /*hide line return spacings*/
-}
-
-.httplug-messages {
-    clear: both;
-    display: flex;
 }
 
 .httplug-scheme-http {

--- a/Resources/views/webprofiler.html.twig
+++ b/Resources/views/webprofiler.html.twig
@@ -104,7 +104,14 @@
                         </div>
                     </div>
                     <div id="httplug-{{ client }}-{{ loop.index }}-details" class="httplug-hidden">
-                        <button data-toggle="#httplug-{{ client }}-{{ loop.index }}-details .httplug-http-body" class="httplug-toggle btn httplug-push-right">Toggle body</button>
+                        <div class="httplug-toolbar">
+                            <div class="httplug-copy-as-curl">
+                                <input readonly="readonly" type="text" value="{{ stack.curlCommand }}" />
+                                <button class="btn tooltip-toggle" aria-label="Copy to clipboard">Copy to clipboard</button>
+                            </div>
+                            <button data-toggle="#httplug-{{ client }}-{{ loop.index }}-stack" class="httplug-toggle btn" >Toggle plugin stack</button>
+                            <button data-toggle="#httplug-{{ client }}-{{ loop.index }}-details .httplug-http-body" class="httplug-toggle btn">Toggle body</button>
+                        </div>
                         <div class="httplug-messages">
                             <div class="httplug-message card">
                                 <h4>Request</h4>
@@ -116,9 +123,6 @@
                             </div>
                         </div>
                         {% if stack.profiles %}
-                            <div class="httplug-center">
-                                <button class="btn httplug-toggle" data-toggle="#httplug-{{ client }}-{{ loop.index }}-stack">Toggle plugin stack</button>
-                            </div>
                             <div id="httplug-{{ client }}-{{ loop.index }}-stack" class="httplug-hidden card">
                                 {% for profile in stack.profiles %}
                                     <h3 class="httplug-plugin-name">{{ profile.plugin }}</h3>

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/options-resolver": "^2.8 || ^3.0",
         "symfony/event-dispatcher": "^2.8 || ^3.0",
         "symfony/framework-bundle": "^2.8 || ^3.0",
-        "php-http/message": "^1.3",
+        "php-http/message": "^1.4",
         "php-http/discovery": "^1.0",
         "twig/twig": "^1.18 || ^2.0"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #108 
| Documentation   | N/A
| License         | MIT

This add the ability to copy any request from the profiler as cURL command!

I also reworked the profiler actions. I moved all possible actions to a kind of toolbar which contains copy as cURL, toggle profile stack and toggle body buttons.

![httplugbundle5](https://cloud.githubusercontent.com/assets/1116116/25700342/a776f2e0-30c7-11e7-9cab-e1146ee5c81f.png)
