### PR TITLE
Display horizontal scrollbar when necessary for profiler messages

### DIFF
--- a/Resources/public/style/httplug.css
+++ b/Resources/public/style/httplug.css
@@ -25,8 +25,7 @@
     padding: 5px;
     flex: 1;
     margin: 5px;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow-x: auto;
     white-space: nowrap;
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | N/A
| License         | MIT

Since #146, messages are truncated which may definitively hide informations to user. I replaced the `text-overflow: ellipsis` with a `overflow-x:auto` to display an horizontal scrollbar when required.
![httplugbundle6](https://cloud.githubusercontent.com/assets/1116116/25700669/f74d033a-30c8-11e7-9076-02bb2aeb23b0.png)

