### PR TITLE
remove stopwatch plugin for discovered clients.

### DIFF
--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -433,9 +433,6 @@ class HttplugExtension extends Extension
         if ($profiling) {
             // To profile the requests, add a StackPlugin as first plugin in the chain.
             $plugins[] = $this->configureStackPlugin($container, $name, $serviceId);
-
-            $this->decoratePluginWithProfilePlugin($container, 'httplug.plugin.stopwatch');
-            $plugins[] = 'httplug.plugin.stopwatch';
         }
 
         $container


### PR DESCRIPTION
The stopwatch plugin is no longer required since time is now collected in ProfileClient.

This was forgotten in #135.

See https://github.com/php-http/HttplugBundle/pull/160#issuecomment-300380456

