### PR TITLE
Make sure $stack is null or Stack. Never boolean.

### DIFF
--- a/Collector/Collector.php
+++ b/Collector/Collector.php
@@ -62,11 +62,15 @@ class Collector extends DataCollector
     }
 
     /**
-     * @return Stack|bool false if no current stack.
+     * @return Stack|null Return null there is no current stack.
      */
     public function getCurrentStack()
     {
-        return end($this->data['stacks']);
+        if (false === $stack = end($this->data['stacks'])) {
+            return null;
+        }
+
+        return $stack;
     }
 
     /**

--- a/Collector/ProfileClient.php
+++ b/Collector/ProfileClient.php
@@ -124,7 +124,7 @@ class ProfileClient implements HttpClient, HttpAsyncClient
      */
     private function collectRequestInformations(RequestInterface $request, Stack $stack = null)
     {
-        if (!$stack) {
+        if (null === $stack) {
             return;
         }
 
@@ -143,7 +143,7 @@ class ProfileClient implements HttpClient, HttpAsyncClient
      */
     private function collectResponseInformations(ResponseInterface $response, StopwatchEvent $event, Stack $stack = null)
     {
-        if (!$stack) {
+        if (null === $stack) {
             return;
         }
 
@@ -163,7 +163,7 @@ class ProfileClient implements HttpClient, HttpAsyncClient
             $this->collectResponseInformations($exception->getResponse(), $event, $stack);
         }
 
-        if (!$stack) {
+        if (null === $stack) {
             return;
         }
 

--- a/Collector/ProfilePlugin.php
+++ b/Collector/ProfilePlugin.php
@@ -58,7 +58,8 @@ class ProfilePlugin implements Plugin
     {
         $profile = new Profile($this->pluginName, $this->formatter->formatRequest($request));
 
-        if (null !== $stack = $this->collector->getCurrentStack()) {
+        $stack = $this->collector->getCurrentStack();
+        if (null !== $stack) {
             $stack->addProfile($profile);
         }
 

--- a/Collector/ProfilePlugin.php
+++ b/Collector/ProfilePlugin.php
@@ -58,7 +58,7 @@ class ProfilePlugin implements Plugin
     {
         $profile = new Profile($this->pluginName, $this->formatter->formatRequest($request));
 
-        if ($stack = $this->collector->getCurrentStack()) {
+        if (null !== $stack = $this->collector->getCurrentStack()) {
             $stack->addProfile($profile);
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes, but they are not released yet
| Deprecations?   | no
| Related tickets | fixes issues from scrutinizer
| Documentation   | 
| License         | MIT

This is just a minor change in the return value of `getCurrentStack`