### PR TITLE
Allow respect_cache_headers to be "false"

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -573,15 +573,20 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
-                ->enumNode('respect_cache_headers')
+                ->scalarNode('respect_cache_headers')
                     ->info('Whether we should care about cache headers or not [DEPRECATED]')
-                    ->values([null, true, false])
                     ->beforeNormalization()
                         ->always(function ($v) {
                             @trigger_error('The option "respect_cache_headers" is deprecated since version 1.3 and will be removed in 2.0. Use "respect_response_cache_directives" instead.', E_USER_DEPRECATED);
 
                             return $v;
                         })
+                    ->end()
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            return !in_array($v, [null, true, false]);
+                        })
+                        ->thenInvalid('Invalid value for respect_cache_headers: %s. Must be "null", "true" or "false"')
                     ->end()
                 ->end()
                 ->variableNode('respect_response_cache_directives')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -584,7 +584,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->validate()
                         ->ifNotInArray([null, true, false])
-                            ->thenInvalid('Value for "respect_cache_headers" must be null or boolean')
+                        ->thenInvalid('Value for "respect_cache_headers" must be null or boolean')
                     ->end()
                 ->end()
                 ->variableNode('respect_response_cache_directives')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -581,10 +581,10 @@ class Configuration implements ConfigurationInterface
 
                             return $v;
                         })
-                        ->end()
+                    ->end()
                     ->validate()
-                    ->ifNotInArray([null, true, false])
-                        ->thenInvalid('Value for "respect_cache_headers" must be null or boolean')
+                        ->ifNotInArray([null, true, false])
+                            ->thenInvalid('Value for "respect_cache_headers" must be null or boolean')
                     ->end()
                 ->end()
                 ->variableNode('respect_response_cache_directives')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -581,12 +581,10 @@ class Configuration implements ConfigurationInterface
 
                             return $v;
                         })
-                    ->end()
+                        ->end()
                     ->validate()
-                        ->ifTrue(function ($v) {
-                            return !in_array($v, [null, true, false]);
-                        })
-                        ->thenInvalid('Invalid value for respect_cache_headers: %s. Must be "null", "true" or "false"')
+                    ->ifNotInArray([null, true, false])
+                        ->thenInvalid('Value for "respect_cache_headers" must be null or boolean')
                     ->end()
                 ->end()
                 ->variableNode('respect_response_cache_directives')

--- a/Tests/Resources/Fixtures/config/bc/issue-166.yml
+++ b/Tests/Resources/Fixtures/config/bc/issue-166.yml
@@ -1,0 +1,6 @@
+httplug:
+    plugins:
+        cache:
+            cache_pool: my_cache_pool
+            config:
+                respect_cache_headers: false

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -329,6 +329,24 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
     }
 
     /**
+     * @group legacy
+     */
+    public function testCacheConfigDeprecationCompatibilityIssue166()
+    {
+        $file = __DIR__.'/../../Resources/Fixtures/config/bc/issue-166.yml';
+        $config = $this->emptyConfig;
+        $config['plugins']['cache'] = array_merge($config['plugins']['cache'], [
+            'enabled' => true,
+            'cache_pool' => 'my_cache_pool',
+            'config' => [
+                'methods' => ['GET', 'HEAD'],
+                'respect_cache_headers' => false,
+            ],
+        ]);
+        $this->assertProcessedConfigurationEquals($config, [$file]);
+    }
+
+    /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage Can't configure both "toolbar" and "profiling" section. The "toolbar" config is deprecated as of version 1.3.0, please only use "profiling".
      */


### PR DESCRIPTION
This PR adds a test for an issue I found. 

We define `respect_cache_headers` like: 

```php
->enumNode('respect_cache_headers')
    ->info('Whether we should care about cache headers or not [DEPRECATED]')
    ->values([null, true, false])
    ->beforeNormalization()
        ->always(function ($v) {
            @trigger_error('The option "respect_cache_headers" is deprecated since version 1.3 and will be removed in 2.0. Use "respect_response_cache_directives" instead.', E_USER_DEPRECATED);

            return $v;
        })
    ->end()
->end()
```

On Symfony 2.8, the EnumNode runs `array_unique` over the possible values. Though, `null` and `false` is treated the same. See https://3v4l.org/KWuNP

This will result in that the possible values for `respect_cache_headers` will only be `true` and `null`. This issue will break BC since we promise that all previous configuration will work on newer versions. 

FYI: In the last release we defined the `respect_cache_headers` like: 

```php
->scalarNode('respect_cache_headers')->defaultTrue()->end()
```