### PR TITLE
Collect the request after the plugin execution

### DIFF
--- a/Collector/Profile.php
+++ b/Collector/Profile.php
@@ -33,12 +33,10 @@ final class Profile
 
     /**
      * @param string $plugin
-     * @param string $request
      */
-    public function __construct($plugin, $request)
+    public function __construct($plugin)
     {
         $this->plugin = $plugin;
-        $this->request = $request;
     }
 
     /**
@@ -55,6 +53,14 @@ final class Profile
     public function getRequest()
     {
         return $this->request;
+    }
+
+    /**
+     * @param string $request
+     */
+    public function setRequest($request)
+    {
+        $this->request = $request;
     }
 
     /**

--- a/Tests/Unit/Collector/ProfilePluginTest.php
+++ b/Tests/Unit/Collector/ProfilePluginTest.php
@@ -77,7 +77,11 @@ class ProfilePluginTest extends \PHPUnit_Framework_TestCase
 
         $this->plugin
             ->method('handleRequest')
-            ->willReturn($this->promise)
+            ->willReturnCallback(function ($request, $next, $first) {
+                $next($request);
+
+                return $this->promise;
+            })
         ;
 
         $this->formatter
@@ -128,6 +132,15 @@ class ProfilePluginTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $this->currentStack->getProfiles());
         $profile = $this->currentStack->getProfiles()[0];
         $this->assertEquals('http.plugin.mock', $profile->getPlugin());
+    }
+
+    public function testCollectRequestInformations()
+    {
+        $this->subject->handleRequest($this->request, function () {
+        }, function () {
+        });
+
+        $profile = $this->currentStack->getProfiles()[0];
         $this->assertEquals('FormattedRequest', $profile->getRequest());
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT

As I explained on Slack, before this fix, the request was collected before the decorated plugin execution and so, changes to the request made by the plugin were displayed in the next plugin in the chain.

Now the request is collected after the plugin execution and so, the plugin changes are displayed within the right plugin block.

Before:
![before](https://cloud.githubusercontent.com/assets/1116116/26082003/bd93083e-39cd-11e7-8593-c7b5cdb862c4.png)

After:
![after](https://cloud.githubusercontent.com/assets/1116116/26082005/c3ae129a-39cd-11e7-94e5-5d02bcc05da4.png)
