### PR TITLE
Profiling might not work with CachePlugin

### DIFF
--- a/Tests/Functional/ProfilingTest.php
+++ b/Tests/Functional/ProfilingTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Http\HttplugBundle\Tests\Functional;
+
+use GuzzleHttp\Psr7\Request;
+use Http\Client\Common\Plugin;
+use Http\Client\Common\PluginClient;
+use Http\Discovery\StreamFactoryDiscovery;
+use Http\HttplugBundle\Collector\Collector;
+use Http\HttplugBundle\Collector\Formatter;
+use Http\HttplugBundle\Collector\ProfileClient;
+use Http\HttplugBundle\Collector\ProfilePlugin;
+use Http\HttplugBundle\Collector\StackPlugin;
+use Http\Message\Formatter\CurlCommandFormatter;
+use Http\Message\Formatter\FullHttpMessageFormatter;
+use Http\Mock\Client;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class ProfilingTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Collector
+     */
+    private $collector;
+
+    /**
+     * @var Formatter
+     */
+    private $formatter;
+
+    /**
+     * @var Stopwatch
+     */
+    private $stopwatch;
+
+    public function setUp()
+    {
+        $this->collector = new Collector([]);
+        $this->formatter = new Formatter(new FullHttpMessageFormatter(), new CurlCommandFormatter());
+        $this->stopwatch = new Stopwatch();
+    }
+
+    public function testCachePluginProfiling()
+    {
+        $pool = new ArrayAdapter();
+
+        $client = $this->createClient([
+            new Plugin\CachePlugin($pool, StreamFactoryDiscovery::find(), [
+                'respect_response_cache_directives' => [],
+                'default_ttl' => 86400,
+            ]),
+        ]);
+
+        $client->sendRequest(new Request('GET', 'https://example.com'));
+        $client->sendRequest(new Request('GET', 'https://example.com'));
+
+        $this->assertCount(2, $this->collector->getStacks());
+        $stack = $this->collector->getStacks()[1];
+        $this->assertEquals('GET', $stack->getRequestMethod());
+        $this->assertEquals('https', $stack->getRequestScheme());
+        $this->assertEquals('/', $stack->getRequestTarget());
+        $this->assertEquals('example.com', $stack->getRequestHost());
+    }
+
+    private function createClient(array $plugins, $clientName = 'Acme', array $clientOptions = [])
+    {
+        $plugins = array_map(function (Plugin $plugin) {
+            return new ProfilePlugin($plugin, $this->collector, $this->formatter, get_class($plugin));
+        }, $plugins);
+
+        array_unshift($plugins, new StackPlugin($this->collector, $this->formatter, $clientName));
+
+        $client = new Client();
+        $client = new ProfileClient($client, $this->collector, $this->formatter, $this->stopwatch);
+        $client = new PluginClient($client, $plugins, $clientOptions);
+
+        return $client;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,13 @@
         "php-http/guzzle6-adapter": "^1.1.1",
         "php-http/react-adapter": "^0.2.1",
         "php-http/buzz-adapter": "^0.3",
+        "php-http/mock-client": "^1.0",
         "symfony/phpunit-bridge": "^3.2",
         "symfony/twig-bundle": "^2.8 || ^3.0",
         "symfony/twig-bridge": "^2.8 || ^3.0",
         "symfony/web-profiler-bundle": "^2.8 || ^3.0",
         "symfony/finder": "^2.7 || ^3.0",
+        "symfony/cache": "^3.1",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | not yet
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | N/A
| License         | MIT

This a a failing functional test about profiling when the `CachePlugin` is involved.

When the cache is hit and the `CachePlugin` does not perform any cache validation, the `ProfileClient` is never reached. This cause the profiled stack about not being complete and will display empty boxes in the profiler panel.