### PR TITLE
Use simple-phpunit to run tests on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 cache:
     directories:
         - $HOME/.composer/cache/files
+        - $HOME/symfony-bridge/.phpunit
 
 php:
     - 5.5
@@ -13,7 +14,10 @@ php:
     - 7.1
 
 env:
-    - TEST_COMMAND="composer test"
+    global:
+        - SYMFONY_DEPRECATIONS_HELPER=weak
+        - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+        - TEST_COMMAND="composer test"
 
 branches:
     except:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "twig/twig": "^1.18 || ^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.5 || ^5.4",
         "php-http/curl-client": "^1.0",
         "php-http/socket-client": "^1.0",
         "php-http/guzzle6-adapter": "^1.1.1",
@@ -43,7 +42,7 @@
         "symfony/web-profiler-bundle": "^2.8 || ^3.0",
         "symfony/finder": "^2.7 || ^3.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^1.0"
+        "matthiasnoback/symfony-dependency-injection-test": "^1.0.1"
     },
     "conflict": {
         "php-http/guzzle6-adapter": "<1.1"
@@ -54,8 +53,8 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit",
-        "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
+        "test": "vendor/bin/simple-phpunit",
+        "test-ci": "vendor/bin/simple-phpunit --coverage-text --coverage-clover=build/coverage.xml"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #175 
| Documentation   | N/A
| License         | MIT


#### What's in this PR?

This remove the `phpunit/phpunit` dev dependency and use `symfony/phpunit-bridge` `simple-phpunit` wrapper to run tests. PHPUnit installation is also cached.

I also moved global environment variables under the `env.global` `.travis.yml` section. Those variables are now hidden from the jobs list. See latest [master build](https://travis-ci.org/php-http/HttplugBundle/builds/247467754) and [current build](https://travis-ci.org/php-http/HttplugBundle/builds/247565808?utm_source=github_status&utm_medium=notification) for comparaison.

I also bumped `matthiasnoback/symfony-dependency-injection-test` minimum version to `^1.0.1` to avoid having `phpunit/phpunit` installed as dependency which caused some autoloading mess.

It looks like this was forgotten when doing #149.
