### PR TITLE
display plugin fqcn instead of plugin service id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
-The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release. 
+The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
+
+## Unreleased
+
+### Changed
+
+- Plugins are now displayed with their FQCN instead of service id.
 
 ## 1.6.0 - 2017-05-22
 

--- a/Collector/ProfilePlugin.php
+++ b/Collector/ProfilePlugin.php
@@ -33,22 +33,15 @@ class ProfilePlugin implements Plugin
     private $formatter;
 
     /**
-     * @var string
-     */
-    private $pluginName;
-
-    /**
      * @param Plugin    $plugin
      * @param Collector $collector
      * @param Formatter $formatter
-     * @param string    $pluginName
      */
-    public function __construct(Plugin $plugin, Collector $collector, Formatter $formatter, $pluginName)
+    public function __construct(Plugin $plugin, Collector $collector, Formatter $formatter)
     {
         $this->plugin = $plugin;
         $this->collector = $collector;
         $this->formatter = $formatter;
-        $this->pluginName = $pluginName;
     }
 
     /**
@@ -56,7 +49,7 @@ class ProfilePlugin implements Plugin
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
-        $profile = new Profile($this->pluginName);
+        $profile = new Profile(get_class($this->plugin));
 
         $stack = $this->collector->getCurrentStack();
         if (null !== $stack) {

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -506,7 +506,6 @@ class HttplugExtension extends Extension
                 new Reference($pluginServiceId.'.debug.inner'),
                 new Reference('httplug.collector.collector'),
                 new Reference('httplug.collector.formatter'),
-                $pluginServiceId,
             ])
             ->setPublic(false);
     }

--- a/Tests/Unit/Collector/ProfilePluginTest.php
+++ b/Tests/Unit/Collector/ProfilePluginTest.php
@@ -141,7 +141,7 @@ class ProfilePluginTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(1, $this->currentStack->getProfiles());
         $profile = $this->currentStack->getProfiles()[0];
-        $this->assertEquals('http.plugin.mock', $profile->getPlugin());
+        $this->assertEquals(get_class($this->plugin), $profile->getPlugin());
     }
 
     public function testCollectRequestInformations()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #109
| Documentation   | screenshot updates
| License         | MIT

#### What's in this PR?

This use the plugin FQCN instead of the service name in the profiler (see https://github.com/php-http/HttplugBundle/issues/109#issuecomment-308970141).

![pluginfqcn](https://user-images.githubusercontent.com/1116116/27791156-fcdf2918-5ff3-11e7-9109-fef6208b0b25.png)

