### PR TITLE
guess client names from collected stacks

### DIFF
--- a/Collector/Collector.php
+++ b/Collector/Collector.php
@@ -20,13 +20,9 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
  */
 class Collector extends DataCollector
 {
-    /**
-     * @param array $clients
-     */
-    public function __construct(array $clients)
+    public function __construct()
     {
         $this->data['stacks'] = [];
-        $this->data['clients'] = $clients;
     }
 
     /**
@@ -98,7 +94,9 @@ class Collector extends DataCollector
      */
     public function getClients()
     {
-        return $this->data['clients'];
+        return array_unique(array_map(function (Stack $stack) {
+            return $stack->getClient();
+        }, $this->data['stacks']));
     }
 
     /**

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -110,12 +110,6 @@ class HttplugExtension extends Extension
                 $container->setAlias('httplug.client.default', 'httplug.client.'.$first);
             }
         }
-
-        if ($profiling) {
-            $container->getDefinition('httplug.collector.collector')
-                ->setArguments([$clients])
-            ;
-        }
     }
 
     /**
@@ -451,11 +445,6 @@ class HttplugExtension extends Extension
                 [],
             ])
         ;
-
-        if ($profiling) {
-            $collector = $container->getDefinition('httplug.collector.collector');
-            $collector->replaceArgument(0, array_merge($collector->getArgument(0), [$name]));
-        }
 
         return $serviceId;
     }

--- a/Tests/Unit/Collector/CollectorTest.php
+++ b/Tests/Unit/Collector/CollectorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Http\HttplugBundle\Tests\Unit\Collector;
+
+use Http\HttplugBundle\Collector\Collector;
+use Http\HttplugBundle\Collector\Stack;
+
+class CollectorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCollectClientNames()
+    {
+        $collector = new Collector();
+
+        $collector->addStack(new Stack('default', 'GET / HTTP/1.1'));
+        $collector->addStack(new Stack('acme', 'GET / HTTP/1.1'));
+        $collector->addStack(new Stack('acme', 'GET / HTTP/1.1'));
+
+        $this->assertEquals(['default', 'acme'], $collector->getClients());
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #109 
| Documentation   | N/A
| License         | MIT

This is a subset of #109 which aims to display clients names in the profiler from what is collected. The only "negative" change here is we no longer display empty tabs for clients which doesn't sent any request.

## ToDo
* [x] Add basic Collector unit test.