### PR TITLE
display children requests as nested in the profiler

### DIFF
--- a/Collector/Collector.php
+++ b/Collector/Collector.php
@@ -20,6 +20,11 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
  */
 class Collector extends DataCollector
 {
+    /**
+     * @var Stack|null
+     */
+    private $activeStack;
+
     public function __construct()
     {
         $this->data['stacks'] = [];
@@ -42,6 +47,38 @@ class Collector extends DataCollector
     }
 
     /**
+     * Mark the stack as active. If a stack was already active, use it as parent for our stack.
+     *
+     * @param Stack $stack
+     */
+    public function activateStack(Stack $stack)
+    {
+        if ($this->activeStack !== null) {
+            $stack->setParent($this->activeStack);
+        }
+
+        $this->activeStack = $stack;
+    }
+
+    /**
+     * Mark the stack as inactive.
+     *
+     * @param Stack $stack
+     */
+    public function deactivateStack(Stack $stack)
+    {
+        $this->activeStack = $stack->getParent();
+    }
+
+    /**
+     * @return Stack|null
+     */
+    public function getActiveStack()
+    {
+        return $this->activeStack;
+    }
+
+    /**
      * @param Stack $stack
      */
     public function addStack(Stack $stack)
@@ -50,23 +87,23 @@ class Collector extends DataCollector
     }
 
     /**
+     * @param Stack $parent
+     *
+     * @return Stack[]
+     */
+    public function getChildrenStacks(Stack $parent)
+    {
+        return array_filter($this->data['stacks'], function (Stack $stack) use ($parent) {
+            return $stack->getParent() === $parent;
+        });
+    }
+
+    /**
      * @return Stack[]
      */
     public function getStacks()
     {
         return $this->data['stacks'];
-    }
-
-    /**
-     * @return Stack|null Return null there is no current stack.
-     */
-    public function getCurrentStack()
-    {
-        if (false === $stack = end($this->data['stacks'])) {
-            return null;
-        }
-
-        return $stack;
     }
 
     /**

--- a/Collector/ProfilePlugin.php
+++ b/Collector/ProfilePlugin.php
@@ -51,10 +51,8 @@ class ProfilePlugin implements Plugin
     {
         $profile = new Profile(get_class($this->plugin));
 
-        $stack = $this->collector->getCurrentStack();
-        if (null !== $stack) {
-            $stack->addProfile($profile);
-        }
+        $stack = $this->collector->getActiveStack();
+        $stack->addProfile($profile);
 
         // wrap the next callback to profile the plugin request changes
         $wrappedNext = function (RequestInterface $request) use ($next, $profile) {
@@ -136,10 +134,6 @@ class ProfilePlugin implements Plugin
      */
     private function collectRequestInformation(RequestInterface $request, Stack $stack = null)
     {
-        if (null === $stack) {
-            return;
-        }
-
         if (empty($stack->getRequestTarget())) {
             $stack->setRequestTarget($request->getRequestTarget());
         }

--- a/Collector/Stack.php
+++ b/Collector/Stack.php
@@ -17,6 +17,11 @@ final class Stack
     private $client;
 
     /**
+     * @var Stack
+     */
+    private $parent;
+
+    /**
      * @var Profile[]
      */
     private $profiles = [];
@@ -102,6 +107,22 @@ final class Stack
     public function getClient()
     {
         return $this->client;
+    }
+
+    /**
+     * @return Stack
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * @param Stack $parent
+     */
+    public function setParent(Stack $parent)
+    {
+        $this->parent = $parent;
     }
 
     /**

--- a/Resources/public/style/httplug.css
+++ b/Resources/public/style/httplug.css
@@ -75,6 +75,13 @@
 }
 
 /**
+ * Stack
+ */
+.httplug-stack>.httplug-stack {
+    margin-left: 2.5em;
+}
+
+/**
  * Stack header
  */
 .httplug-stack-header {

--- a/Resources/views/stack.html.twig
+++ b/Resources/views/stack.html.twig
@@ -1,0 +1,75 @@
+<div class="httplug-stack-header httplug-toggle" data-toggle="#httplug-{{ client }}-{{ id }}-details">
+    <div>
+        {% if stack.failed %}
+            <span class="httplug-stack-failed">✘</span>
+        {% else %}
+            <span class="httplug-stack-success">✔</span>
+        {% endif %}
+        <span class="label httplug-method httplug-method-{{ stack.requestMethod|lower }}">{{ stack.requestMethod }}</span>
+    </div>
+    <div class="label httplug-stack-header-target">
+        <span class="httplug-scheme">{{ stack.requestScheme }}://</span>
+        <span class="httplug-host">{{ stack.requestHost }}</span>
+        <span class="httplug-target">{{ stack.requestTarget }}</span>
+    </div>
+    <div>
+        <span class="label httplug-duration">{{ stack.duration|number_format }} ms</span>
+        {% if stack.responseCode >= 400 and stack.responseCode <= 599 %}
+            <span class="label status-error">{{ stack.responseCode }}</span>
+        {% elseif stack.responseCode >= 300 and stack.responseCode <= 399 %}
+            <span class="label status-warning">{{ stack.responseCode }}</span>
+        {% else %}
+            <span class="label status-success">{{ stack.responseCode }}</span>
+        {% endif %}
+    </div>
+</div>
+<div id="httplug-{{ client }}-{{ id }}-details" class="httplug-hidden">
+    <div class="httplug-toolbar">
+        <div class="httplug-copy-as-curl">
+            <input readonly="readonly" type="text" value="{{ stack.curlCommand }}" />
+            <button class="btn tooltip-toggle" aria-label="Copy to clipboard">Copy to clipboard</button>
+        </div>
+        <button data-toggle="#httplug-{{ client }}-{{ id }}-stack" class="httplug-toggle btn" >Toggle plugin stack</button>
+        <button data-toggle="#httplug-{{ client }}-{{ id }}-details .httplug-http-body" class="httplug-toggle btn">Toggle body</button>
+    </div>
+    <div class="httplug-messages">
+        <div class="httplug-message card">
+            <h4>Request</h4>
+            {{ stack.clientRequest|httplug_markup|nl2br }}
+        </div>
+        <div class="httplug-message card">
+            <h4>Response</h4>
+            {{ stack.clientResponse|httplug_markup|nl2br }}
+        </div>
+    </div>
+    {% if stack.profiles %}
+        <div id="httplug-{{ client }}-{{ id }}-stack" class="httplug-hidden card">
+            {% for profile in stack.profiles %}
+                <h3 class="httplug-plugin-name">{{ profile.plugin }}</h3>
+                <div class="httplug-messages">
+                    <div class="httplug-message">
+                        <h4>Request</h4>
+                        {{ profile.request|httplug_markup|nl2br }}
+                    </div>
+                    <div class="httplug-message">
+                        <h4>Response</h4>
+                        {{ profile.response|httplug_markup|nl2br }}
+                    </div>
+                </div>
+                {% if not loop.last %}
+                    <hr />
+                {% endif %}
+            {% endfor %}
+        </div>
+    {% endif %}
+</div>
+{% for child in collector.childrenStacks(stack) %}
+    <div class="httplug-stack">
+        {% include 'HttplugBundle::stack.html.twig' with {
+            'collector': collector,
+            'client': client,
+            'stack': child,
+            'id': id ~ '-' ~ loop.index
+        } only %}
+    </div>
+{% endfor %}

--- a/Resources/views/webprofiler.html.twig
+++ b/Resources/views/webprofiler.html.twig
@@ -78,71 +78,14 @@
                     These messages are sent by client named "{{ client }}".
                 </p>
 
-                {% for stack in collector.clientStacks(client) %}
-                    <div class="httplug-stack-header httplug-toggle" data-toggle="#httplug-{{ client }}-{{ loop.index }}-details">
-                        <div>
-                            {% if stack.failed %}
-                                <span class="httplug-stack-failed">✘</span>
-                            {% else %}
-                                <span class="httplug-stack-success">✔</span>
-                            {% endif %}
-                            <span class="label httplug-method httplug-method-{{ stack.requestMethod|lower }}">{{ stack.requestMethod }}</span>
-                        </div>
-                        <div class="label httplug-stack-header-target">
-                            <span class="httplug-scheme">{{ stack.requestScheme }}://</span>
-                            <span class="httplug-host">{{ stack.requestHost }}</span>
-                            <span class="httplug-target">{{ stack.requestTarget }}</span>
-                        </div>
-                        <div>
-                            <span class="label httplug-duration">{{ stack.duration|number_format }} ms</span>
-                            {% if stack.responseCode >= 400 and stack.responseCode <= 599 %}
-                                <span class="label status-error">{{ stack.responseCode }}</span>
-                            {% elseif stack.responseCode >= 300 and stack.responseCode <= 399 %}
-                                <span class="label status-warning">{{ stack.responseCode }}</span>
-                            {% else %}
-                                <span class="label status-success">{{ stack.responseCode }}</span>
-                            {% endif %}
-                        </div>
-                    </div>
-                    <div id="httplug-{{ client }}-{{ loop.index }}-details" class="httplug-hidden">
-                        <div class="httplug-toolbar">
-                            <div class="httplug-copy-as-curl">
-                                <input readonly="readonly" type="text" value="{{ stack.curlCommand }}" />
-                                <button class="btn tooltip-toggle" aria-label="Copy to clipboard">Copy to clipboard</button>
-                            </div>
-                            <button data-toggle="#httplug-{{ client }}-{{ loop.index }}-stack" class="httplug-toggle btn" >Toggle plugin stack</button>
-                            <button data-toggle="#httplug-{{ client }}-{{ loop.index }}-details .httplug-http-body" class="httplug-toggle btn">Toggle body</button>
-                        </div>
-                        <div class="httplug-messages">
-                            <div class="httplug-message card">
-                                <h4>Request</h4>
-                                {{ stack.clientRequest|httplug_markup|nl2br }}
-                            </div>
-                            <div class="httplug-message card">
-                                <h4>Response</h4>
-                                {{ stack.clientResponse|httplug_markup|nl2br }}
-                            </div>
-                        </div>
-                        {% if stack.profiles %}
-                            <div id="httplug-{{ client }}-{{ loop.index }}-stack" class="httplug-hidden card">
-                                {% for profile in stack.profiles %}
-                                    <h3 class="httplug-plugin-name">{{ profile.plugin }}</h3>
-                                    <div class="httplug-messages">
-                                        <div class="httplug-message">
-                                            <h4>Request</h4>
-                                            {{ profile.request|httplug_markup|nl2br }}
-                                        </div>
-                                        <div class="httplug-message">
-                                            <h4>Response</h4>
-                                            {{ profile.response|httplug_markup|nl2br }}
-                                        </div>
-                                    </div>
-                                    {% if not loop.last %}
-                                        <hr />
-                                    {% endif %}
-                                {% endfor %}
-                            </div>
-                        {% endif %}
+                {% for stack in collector.clientStacks(client) if not stack.parent %}
+                    <div class="httplug-stack">
+                        {% include 'HttplugBundle::stack.html.twig' with {
+                            'collector': collector,
+                            'client': client,
+                            'stack': stack,
+                            'id': loop.index
+                        } only %}
                     </div>
                 {% endfor %}
             </div>

--- a/Tests/Unit/Collector/CollectorTest.php
+++ b/Tests/Unit/Collector/CollectorTest.php
@@ -17,4 +17,55 @@ class CollectorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(['default', 'acme'], $collector->getClients());
     }
+
+    public function testActivateStack()
+    {
+        $parent = new Stack('acme', 'GET / HTTP/1.1');
+        $stack = new Stack('acme', 'GET / HTTP/1.1');
+
+        $collector = new Collector();
+
+        $collector->activateStack($parent);
+        $collector->activateStack($stack);
+
+        $this->assertEquals($parent, $stack->getParent());
+        $this->assertEquals($stack, $collector->getActiveStack());
+    }
+
+    public function testDeactivateStack()
+    {
+        $stack = new Stack('acme', 'GET / HTTP/1.1');
+        $collector = new Collector();
+
+        $collector->activateStack($stack);
+        $this->assertNotNull($collector->getActiveStack());
+
+        $collector->deactivateStack($stack);
+        $this->assertNull($collector->getActiveStack());
+    }
+
+    public function testDeactivateStackSetParentAsActiveStack()
+    {
+        $parent = new Stack('acme', 'GET / HTTP/1.1');
+        $stack = new Stack('acme', 'GET / HTTP/1.1');
+
+        $collector = new Collector();
+
+        $collector->activateStack($parent);
+        $collector->activateStack($stack);
+        $collector->deactivateStack($stack);
+
+        $this->assertEquals($parent, $collector->getActiveStack());
+    }
+
+    public function testAddStack()
+    {
+        $stack = new Stack('acme', 'GET / HTTP/1.1');
+        $collector = new Collector();
+
+        $collector->addStack($stack);
+
+        $this->assertEquals(['acme'], $collector->getClients());
+        $this->assertEquals([$stack], $collector->getClientStacks('acme'));
+    }
 }

--- a/Tests/Unit/Collector/ProfilePluginTest.php
+++ b/Tests/Unit/Collector/ProfilePluginTest.php
@@ -81,7 +81,7 @@ class ProfilePluginTest extends \PHPUnit_Framework_TestCase
         $this->formatter = $this->getMockBuilder(Formatter::class)->disableOriginalConstructor()->getMock();
 
         $this->collector
-            ->method('getCurrentStack')
+            ->method('getActiveStack')
             ->willReturn($this->currentStack)
         ;
 

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.5 || ^5.4",
+        "phpunit/php-token-stream": "^1.1.8",
         "php-http/curl-client": "^1.0",
         "php-http/socket-client": "^1.0",
         "php-http/guzzle6-adapter": "^1.1.1",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #109 
| Documentation   | update screenshots?
| License         | MIT

While working on #109, I just discovered the refactoring I was doing allows to easily display children requests as nested in the profiler. To keep things small, I decided to do a separate PR which add a nice feature in the profiler and helps to fix #109.

This introduce the concept of active stack. When coming into the StackPlugin, the created stack is made active. Then the request go through every plugins to reach the ProfileClient. The ProfileClient deactivate the stack. Then other code execute, maybe an other request. Then when ProfileClient callbacks are executed, the stack is set as active until we reach StackPlugin callbacks where the stack is marked as inactive.

I also removed the null $stack checks as #133 is definitively solved (since #154).