### PR TITLE
Add discovered clients functional tests

### DIFF
--- a/Tests/Functional/DiscoveredClientsTest.php
+++ b/Tests/Functional/DiscoveredClientsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Http\HttplugBundle\Tests\Functional;
+
+use Http\Client\Common\PluginClient;
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use Http\HttplugBundle\Collector\StackPlugin;
+use Nyholm\NSA;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class DiscoveredClientsTest extends WebTestCase
+{
+    public function testDiscoveredClient()
+    {
+        $container = $this->getContainer(false);
+
+        $this->assertTrue($container->has('httplug.auto_discovery.auto_discovered_client'));
+
+        $service = $container->get('httplug.auto_discovery.auto_discovered_client');
+
+        $this->assertInstanceOf(PluginClient::class, $service);
+        $this->assertInstanceOf(HttpClient::class, NSA::getProperty($service, 'client'));
+        $this->assertEmpty(NSA::getProperty($service, 'plugins'));
+    }
+
+    public function testDiscoveredAsyncClient()
+    {
+        $container = $this->getContainer(false);
+
+        $this->assertTrue($container->has('httplug.auto_discovery.auto_discovered_async'));
+
+        $service = $container->get('httplug.auto_discovery.auto_discovered_async');
+
+        $this->assertInstanceOf(PluginClient::class, $service);
+        $this->assertInstanceOf(HttpAsyncClient::class, NSA::getProperty($service, 'client'));
+        $this->assertEmpty(NSA::getProperty($service, 'plugins'));
+    }
+
+    public function testDiscoveredClientWithProfilingEnabled()
+    {
+        $container = $this->getContainer(true);
+
+        $this->assertTrue($container->has('httplug.auto_discovery.auto_discovered_client'));
+
+        $service = $container->get('httplug.auto_discovery.auto_discovered_client');
+
+        $this->assertInstanceOf(PluginClient::class, $service);
+        $this->assertInstanceOf(HttpClient::class, NSA::getProperty($service, 'client'));
+
+        $plugins = NSA::getProperty($service, 'plugins');
+        $this->assertCount(1, $plugins);
+        $this->assertInstanceOf(StackPlugin::class, $plugins[0]);
+        $this->assertEquals('auto_discovered_client', NSA::getProperty($plugins[0], 'client'));
+    }
+
+    public function testDiscoveredAsyncClientWithProfilingEnabled()
+    {
+        $container = $this->getContainer(true);
+
+        $this->assertTrue($container->has('httplug.auto_discovery.auto_discovered_async'));
+
+        $service = $container->get('httplug.auto_discovery.auto_discovered_async');
+
+        $this->assertInstanceOf(PluginClient::class, $service);
+        $this->assertInstanceOf(HttpAsyncClient::class, NSA::getProperty($service, 'client'));
+
+        $plugins = NSA::getProperty($service, 'plugins');
+        $this->assertCount(1, $plugins);
+        $this->assertInstanceOf(StackPlugin::class, $plugins[0]);
+        $this->assertEquals('auto_discovered_async', NSA::getProperty($plugins[0], 'client'));
+    }
+
+    private function getContainer($debug)
+    {
+        static::bootKernel(['debug' => $debug]);
+
+        return static::$kernel->getContainer();
+    }
+}

--- a/Tests/Resources/app/config/config.yml
+++ b/Tests/Resources/app/config/config.yml
@@ -3,6 +3,8 @@ framework:
   test: ~
 
 httplug:
+    discovery:
+        async_client: auto
     clients:
         acme:
             factory: httplug.factory.curl

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "symfony/finder": "^2.7 || ^3.0",
         "symfony/cache": "^3.1",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^1.0"
+        "matthiasnoback/symfony-dependency-injection-test": "^1.0",
+        "nyholm/nsa": "^1.1"
     },
     "conflict": {
         "php-http/guzzle6-adapter": "<1.1"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #109 
| Documentation   | n/a
| License         | MIT

This just add functional tests on discovered clients as I will refactor this to use xml configuration instead of PHP in `HttplugExtension`. This will help me to not break discovered clients!