### PR TITLE
Use xml to configure discovered clients

### DIFF
--- a/Resources/config/data-collector.xml
+++ b/Resources/config/data-collector.xml
@@ -26,6 +26,42 @@
             <tag name="twig.extension" />
         </service>
 
+        <!-- Discovered clients -->
+        <service id="httplug.collector.auto_discovered_client" class="Http\HttplugBundle\Collector\ProfileClient" decorates="httplug.auto_discovery.auto_discovered_client" decoration-priority="2" public="false">
+            <argument type="service" id="httplug.collector.auto_discovered_client.inner"/>
+            <argument type="service" id="httplug.collector.collector"/>
+            <argument type="service" id="httplug.collector.formatter"/>
+            <argument type="service" id="debug.stopwatch"/>
+        </service>
+
+        <service id="httplug.collector.auto_discovered_async" class="Http\HttplugBundle\Collector\ProfileClient" decorates="httplug.auto_discovery.auto_discovered_async" decoration-priority="2" public="false">
+            <argument type="service" id="httplug.collector.auto_discovered_async.inner"/>
+            <argument type="service" id="httplug.collector.collector"/>
+            <argument type="service" id="httplug.collector.formatter"/>
+            <argument type="service" id="debug.stopwatch"/>
+        </service>
+
+        <service id="httplug.auto_discovery.auto_discovered_client.plugin" class="Http\Client\Common\PluginClient" decorates="httplug.auto_discovery.auto_discovered_client" public="false">
+            <argument type="service" id="httplug.auto_discovery.auto_discovered_client.plugin.inner"/>
+            <argument type="collection">
+                <argument type="service">
+                    <service parent="httplug.plugin.stack">
+                        <argument>auto_discovered_client</argument>
+                    </service>
+                </argument>
+            </argument>
+        </service>
+        <service id="httplug.auto_discovery.auto_discovered_async.plugin" class="Http\Client\Common\PluginClient" decorates="httplug.auto_discovery.auto_discovered_async" public="false">
+            <argument type="service" id="httplug.auto_discovery.auto_discovered_async.plugin.inner"/>
+            <argument type="collection">
+                <argument type="service">
+                    <service parent="httplug.plugin.stack">
+                        <argument>auto_discovered_async</argument>
+                    </service>
+                </argument>
+            </argument>
+        </service>
+
         <!-- ClientFactories -->
         <service id="httplug.collector.factory.auto" class="Http\HttplugBundle\Collector\ProfileClientFactory" decorates="httplug.factory.auto" public="false">
             <argument type="service" id="httplug.collector.factory.auto.inner"/>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,7 +5,25 @@
 
     <services>
         <service id="httplug.strategy" class="Http\HttplugBundle\Discovery\ConfiguredClientsStrategy">
+            <argument type="service" id="httplug.auto_discovery.auto_discovered_client" on-invalid="null"/>
+            <argument type="service" id="httplug.auto_discovery.auto_discovered_async" on-invalid="null"/>
             <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="httplug.auto_discovery.auto_discovered_client" class="Http\Client\HttpClient">
+            <factory class="Http\Discovery\HttpClientDiscovery" method="find" />
+        </service>
+
+        <service id="httplug.auto_discovery.auto_discovered_async" class="Http\Client\HttpAsyncClient">
+            <factory class="Http\Discovery\HttpAsyncClientDiscovery" method="find" />
+        </service>
+
+        <!-- Decorate discovered clients with PluginClient -->
+        <service id="httplug.auto_discovery.auto_discovered_client.plugin" class="Http\Client\Common\PluginClient" decorates="httplug.auto_discovery.auto_discovered_client" decoration-priority="1" public="false">
+            <argument type="service" id="httplug.auto_discovery.auto_discovered_client.plugin.inner"/>
+        </service>
+        <service id="httplug.auto_discovery.auto_discovered_async.plugin" class="Http\Client\Common\PluginClient" decorates="httplug.auto_discovery.auto_discovered_async" decoration-priority="1" public="false">
+            <argument type="service" id="httplug.auto_discovery.auto_discovered_async.plugin.inner"/>
         </service>
 
         <!-- Discovery with autowiring support for Symfony 3.3+ -->


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #109 
| Documentation   | n/a
| License         | MIT

This move discovered clients configuration from `HttplugExtension` to `services.xml` and `data-collector.xml`.

### To Do
* [x] Add tests when discovered client is set to a configured service.