### PR TITLE
use service locator for configured client strategy

### DIFF
--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -383,6 +384,14 @@ class HttplugExtension extends Extension
             $container->removeDefinition('httplug.strategy');
 
             return;
+        }
+
+        if (!class_exists(ServiceLocator::class)) {
+            $container->getDefinition('httplug.strategy')->setArguments([
+                new Reference('service_container'),
+                in_array($httpClient, ['auto', null], true) ? 'httplug.auto_discovery.auto_discovered_client' : $httpClient,
+                in_array($asyncHttpClient, ['auto', null], true) ? 'httplug.auto_discovery.auto_discovered_async' : $asyncHttpClient,
+            ]);
         }
     }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,9 +4,18 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="httplug.strategy.locator" class="Symfony\Component\DependencyInjection\ServiceLocator" public="false">
+            <argument type="collection">
+                <argument key="httplug.auto_discovery.auto_discovered_client" type="service" id="httplug.auto_discovery.auto_discovered_client" />
+                <argument key="httplug.auto_discovery.auto_discovered_async" type="service" id="httplug.auto_discovery.auto_discovered_async" />
+            </argument>
+            <tag name="container.service_locator" />
+        </service>
         <service id="httplug.strategy" class="Http\HttplugBundle\Discovery\ConfiguredClientsStrategy">
-            <argument type="service" id="httplug.auto_discovery.auto_discovered_client" on-invalid="null"/>
-            <argument type="service" id="httplug.auto_discovery.auto_discovered_async" on-invalid="null"/>
+            <argument type="service" id="httplug.strategy.locator" />
+            <argument>httplug.auto_discovery.auto_discovered_client</argument>
+            <argument>httplug.auto_discovery.auto_discovered_async</argument>
+
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/Tests/Functional/DiscoveredClientsTest.php
+++ b/Tests/Functional/DiscoveredClientsTest.php
@@ -6,6 +6,7 @@ use Http\Client\Common\PluginClient;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\HttplugBundle\Collector\StackPlugin;
+use Http\HttplugBundle\Discovery\ConfiguredClientsStrategy;
 use Nyholm\NSA;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -88,10 +89,13 @@ class DiscoveredClientsTest extends WebTestCase
         $this->assertFalse($container->has('httplug.auto_discovery.auto_discovered_async'));
         $this->assertTrue($container->has('httplug.strategy'));
 
-        $strategy = $container->get('httplug.strategy');
+        $container->get('httplug.strategy');
 
-        $this->assertEquals($container->get('httplug.client.acme'), NSA::getProperty($strategy, 'client'));
-        $this->assertEquals($container->get('httplug.client.acme'), NSA::getProperty($strategy, 'asyncClient'));
+        $httpClientCandidate = ConfiguredClientsStrategy::getCandidates(HttpClient::class)[0]['class'];
+        $httpAsyncClientCandidate = ConfiguredClientsStrategy::getCandidates(HttpAsyncClient::class)[0]['class'];
+
+        $this->assertEquals($container->get('httplug.client.acme'), $httpClientCandidate());
+        $this->assertEquals($container->get('httplug.client.acme'), $httpAsyncClientCandidate());
     }
 
     private function getContainer($debug, $environment = 'test')

--- a/Tests/Unit/Discovery/ConfiguredClientsStrategyTest.php
+++ b/Tests/Unit/Discovery/ConfiguredClientsStrategyTest.php
@@ -5,6 +5,8 @@ namespace Http\HttplugBundle\Tests\Unit\Discovery;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\HttplugBundle\Discovery\ConfiguredClientsStrategy;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class ConfiguredClientsStrategyTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,7 +14,19 @@ class ConfiguredClientsStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $httpClient = $this->getMockBuilder(HttpClient::class)->getMock();
         $httpAsyncClient = $this->getMockBuilder(HttpAsyncClient::class)->getMock();
-        $strategy = new ConfiguredClientsStrategy($httpClient, $httpAsyncClient);
+        $locator = $this->getLocatorMock();
+        $locator
+            ->expects($this->exactly(2))
+            ->method('has')
+            ->willReturn(true)
+        ;
+        $locator
+            ->expects($this->exactly(2))
+            ->method('get')
+            ->will($this->onConsecutiveCalls($httpClient, $httpAsyncClient))
+        ;
+
+        $strategy = new ConfiguredClientsStrategy($locator, 'httplug.auto_discovery.auto_discovered_client', 'httplug.auto_discovery.auto_discovered_async');
 
         $candidates = $strategy::getCandidates(HttpClient::class);
         $candidate = array_shift($candidates);
@@ -25,7 +39,18 @@ class ConfiguredClientsStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCandidatesEmpty()
     {
-        $strategy = new ConfiguredClientsStrategy(null, null);
+        $locator = $this->getLocatorMock();
+        $locator
+            ->expects($this->exactly(2))
+            ->method('has')
+            ->willReturn(false)
+        ;
+        $locator
+            ->expects($this->never())
+            ->method('get')
+        ;
+
+        $strategy = new ConfiguredClientsStrategy($locator, 'httplug.auto_discovery.auto_discovered_client', 'httplug.auto_discovery.auto_discovered_async');
 
         $candidates = $strategy::getCandidates(HttpClient::class);
         $this->assertEquals([], $candidates);
@@ -37,7 +62,23 @@ class ConfiguredClientsStrategyTest extends \PHPUnit_Framework_TestCase
     public function testGetCandidatesEmptyAsync()
     {
         $httpClient = $this->getMockBuilder(HttpClient::class)->getMock();
-        $strategy = new ConfiguredClientsStrategy($httpClient, null);
+
+        $locator = $this->getLocatorMock();
+        $locator
+            ->expects($this->exactly(2))
+            ->method('has')
+            ->willReturnMap([
+                ['httplug.auto_discovery.auto_discovered_client', true],
+                ['httplug.auto_discovery.auto_discovered_async', false],
+            ])
+        ;
+        $locator
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($httpClient)
+        ;
+
+        $strategy = new ConfiguredClientsStrategy($locator, 'httplug.auto_discovery.auto_discovered_client', 'httplug.auto_discovery.auto_discovered_async');
 
         $candidates = $strategy::getCandidates(HttpClient::class);
         $candidate = array_shift($candidates);
@@ -50,7 +91,23 @@ class ConfiguredClientsStrategyTest extends \PHPUnit_Framework_TestCase
     public function testGetCandidatesEmptySync()
     {
         $httpAsyncClient = $this->getMockBuilder(HttpAsyncClient::class)->getMock();
-        $strategy = new ConfiguredClientsStrategy(null, $httpAsyncClient);
+
+        $locator = $this->getLocatorMock();
+        $locator
+            ->expects($this->exactly(2))
+            ->method('has')
+            ->willReturnMap([
+                ['httplug.auto_discovery.auto_discovered_client', false],
+                ['httplug.auto_discovery.auto_discovered_async', true],
+            ])
+        ;
+        $locator
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($httpAsyncClient)
+        ;
+
+        $strategy = new ConfiguredClientsStrategy($locator, 'httplug.auto_discovery.auto_discovered_client', 'httplug.auto_discovery.auto_discovered_async');
 
         $candidates = $strategy::getCandidates(HttpClient::class);
         $this->assertEquals([], $candidates);
@@ -58,5 +115,17 @@ class ConfiguredClientsStrategyTest extends \PHPUnit_Framework_TestCase
         $candidates = $strategy::getCandidates(HttpAsyncClient::class);
         $candidate = array_shift($candidates);
         $this->assertEquals($httpAsyncClient, $candidate['class']());
+    }
+
+    /**
+     * @return ContainerInterface|ServiceLocator
+     */
+    private function getLocatorMock()
+    {
+        if (class_exists(ServiceLocator::class)) {
+            return $this->getMockBuilder(ServiceLocator::class)->disableOriginalConstructor()->getMock();
+        }
+
+        return $this->getMockBuilder(ContainerInterface::class)->getMock();
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes?
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #109 
| Documentation   | n/a
| License         | MIT

#### What's in this PR?

When available (Symfony 3.3+), a `ServiceLocator` is used in the `ConfiguredClientStrategy` to lazy load discoverable clients. A fallback injecting the Container is implemented for older Symfony versions.

#### Why?

This is required to solve a chicken/egg problem for #109. This should also improve a few resources usage by only building clients when discovery is called (before discovered clients were built at `kernel.request` or `console.command`).