### PR TITLE
Deprecate DummyClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 - Plugins are now displayed with their FQCN instead of service id.
 
+### Deprecated
+
+- The `DummyClient` interface.
+
 ## 1.6.0 - 2017-05-22
 
 ### Added

--- a/ClientFactory/DummyClient.php
+++ b/ClientFactory/DummyClient.php
@@ -2,6 +2,8 @@
 
 namespace Http\HttplugBundle\ClientFactory;
 
+@trigger_error('The '.__NAMESPACE__.'\DummyClient interface is deprecated since version 1.7 and will be removed in 2.0.', E_USER_DEPRECATED);
+
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -6,7 +6,7 @@ use Http\Client\Common\BatchClient;
 use Http\Client\Common\FlexibleHttpClient;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\Plugin\AuthenticationPlugin;
-use Http\HttplugBundle\ClientFactory\DummyClient;
+use Http\Client\Common\PluginClient;
 use Http\HttplugBundle\ClientFactory\PluginClientFactory;
 use Http\HttplugBundle\Collector\ProfilePlugin;
 use Http\Message\Authentication\BasicAuth;
@@ -284,7 +284,7 @@ class HttplugExtension extends Extension
         }
 
         $container
-            ->register($serviceId, DummyClient::class)
+            ->register($serviceId, PluginClient::class)
             ->setFactory([PluginClientFactory::class, 'createPluginClient'])
             ->addArgument(
                 array_map(


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT

This deprecate the DummyClient interface which was only used for hinting classes in the DI container. I replaced the only usage with PluginClient as it's what the service really is.