### PR TITLE
Don't use dependency injection decoration for plugin profiling

### DIFF
--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -273,9 +273,11 @@ class HttplugExtension extends Extension
         $pluginClientOptions = [];
         if ($profiling) {
             //Decorate each plugin with a ProfilePlugin instance.
-            foreach ($plugins as $pluginServiceId) {
+            $plugins = array_map(function ($pluginServiceId) use ($container) {
                 $this->decoratePluginWithProfilePlugin($container, $pluginServiceId);
-            }
+
+                return $pluginServiceId.'.debug';
+            }, $plugins);
 
             // To profile the requests, add a StackPlugin as first plugin in the chain.
             $stackPluginId = $this->configureStackPlugin($container, $clientName, $serviceId);
@@ -427,9 +429,8 @@ class HttplugExtension extends Extension
     private function decoratePluginWithProfilePlugin(ContainerBuilder $container, $pluginServiceId)
     {
         $container->register($pluginServiceId.'.debug', ProfilePlugin::class)
-            ->setDecoratedService($pluginServiceId)
             ->setArguments([
-                new Reference($pluginServiceId.'.debug.inner'),
+                new Reference($pluginServiceId),
                 new Reference('httplug.collector.collector'),
                 new Reference('httplug.collector.formatter'),
             ])

--- a/Tests/Resources/app/config/config_test.yml
+++ b/Tests/Resources/app/config/config_test.yml
@@ -12,7 +12,7 @@ httplug:
                 -
                     decoder:
                         use_content_encoding: false
-                - httplug.plugin.redirect
+                - app.http.plugin.custom
                 -
                     add_host:
                         host: "http://localhost:8000"
@@ -22,3 +22,7 @@ httplug:
                             type: basic
                             username: foo
                             password: bar
+
+services:
+    app.http.plugin.custom:
+        class: Http\Client\Common\Plugin\RedirectPlugin

--- a/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -117,14 +117,14 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
 
         $plugins = [
             'httplug.client.acme.plugin.stack',
-            'httplug.client.acme.plugin.decoder',
-            'httplug.plugin.redirect',
-            'httplug.client.acme.plugin.add_host',
-            'httplug.client.acme.plugin.header_append',
-            'httplug.client.acme.plugin.header_defaults',
-            'httplug.client.acme.plugin.header_set',
-            'httplug.client.acme.plugin.header_remove',
-            'httplug.client.acme.authentication.my_basic',
+            'httplug.client.acme.plugin.decoder.debug',
+            'httplug.plugin.redirect.debug',
+            'httplug.client.acme.plugin.add_host.debug',
+            'httplug.client.acme.plugin.header_append.debug',
+            'httplug.client.acme.plugin.header_defaults.debug',
+            'httplug.client.acme.plugin.header_set.debug',
+            'httplug.client.acme.plugin.header_remove.debug',
+            'httplug.client.acme.authentication.my_basic.debug',
         ];
         $pluginReferences = array_map(function ($id) {
             return new Reference($id);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #191 
| Documentation   | n/a
| License         | MIT

This fix #191 by no longer use Symfony dependency injection decoration for plugin profiling.