### PR TITLE
Fix profiler display when using in a symfony/flex project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## unreleased
+
+### Fixed
+
+- Display of the profiler panel when used in a symfony/flex project.
+
 ## 1.7.0 - 2017-07-25
 
 ### Added

--- a/Resources/config/data-collector.xml
+++ b/Resources/config/data-collector.xml
@@ -14,7 +14,7 @@
         </service>
 
         <service id="httplug.collector.collector" class="Http\HttplugBundle\Collector\Collector" public="false">
-            <tag name="data_collector" template="HttplugBundle::webprofiler.html.twig" priority="200" id="httplug"/>
+            <tag name="data_collector" template="@Httplug/webprofiler.html.twig" priority="200" id="httplug"/>
         </service>
 
         <service id="httplug.plugin.stack" class="Http\HttplugBundle\Collector\StackPlugin" public="false" abstract="true">

--- a/Tests/Functional/ProfilerTest.php
+++ b/Tests/Functional/ProfilerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Http\HttplugBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ProfilerTest extends WebTestCase
+{
+    public function testShowProfiler()
+    {
+        $client = static::createClient();
+
+        //Browse any page to get a profile
+        $client->request('GET', '/');
+
+        $crawler = $client->request('GET', '/_profiler/latest?panel=httplug');
+        $title = $crawler->filterXPath('//*[@id="collector-content"]/h2');
+
+        $this->assertCount(1, $title);
+        $this->assertEquals('HTTPlug', $title->html());
+    }
+}

--- a/Tests/Resources/app/AppKernel.php
+++ b/Tests/Resources/app/AppKernel.php
@@ -1,10 +1,16 @@
 <?php
 
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
 
 class AppKernel extends Kernel
 {
+    use MicroKernelTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -26,12 +32,22 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
     {
         $loader->load(__DIR__.'/config/config_'.$this->getEnvironment().'.yml');
         if ($this->isDebug()) {
             $loader->load(__DIR__.'/config/config_debug.yml');
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureRoutes(RouteCollectionBuilder $routes)
+    {
+        $routes->import('@WebProfilerBundle/Resources/config/routing/wdt.xml', '/_wdt');
+        $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml', '/_profiler');
+        $routes->add('/', 'kernel:indexAction');
     }
 
     /**
@@ -56,5 +72,10 @@ class AppKernel extends Kernel
     protected function getContainerBaseClass()
     {
         return '\PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer';
+    }
+
+    public function indexAction()
+    {
+        return new Response();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "symfony/framework-bundle": "^2.8 || ^3.0",
         "php-http/message": "^1.4",
         "php-http/discovery": "^1.0",
-        "twig/twig": "^1.18 || ^2.0"
+        "twig/twig": "^1.18 || ^2.0",
+        "symfony/asset": "^2.8 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.5 || ^5.4",
@@ -45,6 +46,8 @@
         "symfony/web-profiler-bundle": "^2.8 || ^3.0",
         "symfony/finder": "^2.7 || ^3.0",
         "symfony/cache": "^3.1",
+        "symfony/browser-kit": "^2.8 || ^3.0",
+        "symfony/dom-crawler": "^2.8 || ^3.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "nyholm/nsa": "^1.1"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT

This fix the profiler panel display when used in a symfony/flex application.

I added a test to ensure the panel is loading (the case is with no requests sent).

The bug was caused by the profiler template path which was using the old twig path syntax (no `@` and `::`).

I also found that the profiler is dependent on the `symfony/asset` component.
