### PR TITLE
Added more clear exception when logger service is not found

### DIFF
--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -162,6 +162,9 @@ class HttplugExtension extends Extension
                 $definition->replaceArgument(0, new Reference($config['journal']));
                 break;
             case 'logger':
+                if (!$container->has($config['logger'])) {
+                    throw new \LogicException(sprintf('To use the LoggerPlugin you must specify a service that implements PSR3 at httplug.plugins.logger.logger. Current value "%s" is not a valid service.', $config['logger']));
+                }
                 $definition->replaceArgument(0, new Reference($config['logger']));
                 if (!empty($config['formatter'])) {
                     $definition->replaceArgument(1, new Reference($config['formatter']));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes.. maybe
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

When one is using the Logger plugin and the default MonologBundle is not installed you would get an error message like:

> The service "httplug.client" has a dependency on a non-existent service "logger".


This PR makes that error message more clear. 

Ping @Koc can you confirm that you had the logger plugin configured?

Ref: https://github.com/symfony/recipes-contrib/issues/67#issuecomment-320227761