### PR TITLE
Don't use PluginClient for discovered clients

### DIFF
--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -361,7 +361,6 @@ class HttplugExtension extends Extension
         if ($httpClient !== 'auto') {
             $container->removeDefinition('httplug.auto_discovery.auto_discovered_client');
             $container->removeDefinition('httplug.collector.auto_discovered_client');
-            $container->removeDefinition('httplug.auto_discovery.auto_discovered_client.plugin');
 
             if (!empty($httpClient)) {
                 $container->setAlias('httplug.auto_discovery.auto_discovered_client', $httpClient);
@@ -373,7 +372,6 @@ class HttplugExtension extends Extension
         if ($asyncHttpClient !== 'auto') {
             $container->removeDefinition('httplug.auto_discovery.auto_discovered_async');
             $container->removeDefinition('httplug.collector.auto_discovered_async');
-            $container->removeDefinition('httplug.auto_discovery.auto_discovered_async.plugin');
 
             if (!empty($asyncHttpClient)) {
                 $container->setAlias('httplug.auto_discovery.auto_discovered_async', $asyncHttpClient);

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -149,37 +149,45 @@ class HttplugExtension extends Extension
                     ->replaceArgument(0, new Reference($config['cache_pool']))
                     ->replaceArgument(1, new Reference($config['stream_factory']))
                     ->replaceArgument(2, $config['config']);
+
                 break;
             case 'cookie':
                 $definition->replaceArgument(0, new Reference($config['cookie_jar']));
+
                 break;
             case 'decoder':
                 $definition->addArgument([
                     'use_content_encoding' => $config['use_content_encoding'],
                 ]);
+
                 break;
             case 'history':
                 $definition->replaceArgument(0, new Reference($config['journal']));
+
                 break;
             case 'logger':
                 $definition->replaceArgument(0, new Reference($config['logger']));
                 if (!empty($config['formatter'])) {
                     $definition->replaceArgument(1, new Reference($config['formatter']));
                 }
+
                 break;
             case 'redirect':
                 $definition->addArgument([
                     'preserve_header' => $config['preserve_header'],
                     'use_default_for_multiple' => $config['use_default_for_multiple'],
                 ]);
+
                 break;
             case 'retry':
                 $definition->addArgument([
                     'retries' => $config['retry'],
                 ]);
+
                 break;
             case 'stopwatch':
                 $definition->replaceArgument(0, new Reference($config['stopwatch']));
+
                 break;
 
             /* client specific plugins */
@@ -191,12 +199,14 @@ class HttplugExtension extends Extension
                 $definition->replaceArgument(1, [
                     'replace' => $config['replace'],
                 ]);
+
                 break;
             case 'header_append':
             case 'header_defaults':
             case 'header_set':
             case 'header_remove':
                 $definition->replaceArgument(0, $config['headers']);
+
                 break;
 
             default:
@@ -220,19 +230,23 @@ class HttplugExtension extends Extension
                 case 'bearer':
                     $container->register($authServiceKey, Bearer::class)
                         ->addArgument($values['token']);
+
                     break;
                 case 'basic':
                     $container->register($authServiceKey, BasicAuth::class)
                         ->addArgument($values['username'])
                         ->addArgument($values['password']);
+
                     break;
                 case 'wsse':
                     $container->register($authServiceKey, Wsse::class)
                         ->addArgument($values['username'])
                         ->addArgument($values['password']);
+
                     break;
                 case 'service':
                     $authServiceKey = $values['service'];
+
                     break;
                 default:
                     throw new \LogicException(sprintf('Unknown authentication type: "%s"', $values['type']));

--- a/Resources/config/data-collector.xml
+++ b/Resources/config/data-collector.xml
@@ -27,39 +27,18 @@
         </service>
 
         <!-- Discovered clients -->
-        <service id="httplug.collector.auto_discovered_client" class="Http\HttplugBundle\Collector\ProfileClient" decorates="httplug.auto_discovery.auto_discovered_client" decoration-priority="2" public="false">
+        <service id="httplug.collector.auto_discovered_client" class="Http\HttplugBundle\Collector\ProfileClient" decorates="httplug.auto_discovery.auto_discovered_client" public="false">
             <argument type="service" id="httplug.collector.auto_discovered_client.inner"/>
             <argument type="service" id="httplug.collector.collector"/>
             <argument type="service" id="httplug.collector.formatter"/>
             <argument type="service" id="debug.stopwatch"/>
         </service>
 
-        <service id="httplug.collector.auto_discovered_async" class="Http\HttplugBundle\Collector\ProfileClient" decorates="httplug.auto_discovery.auto_discovered_async" decoration-priority="2" public="false">
+        <service id="httplug.collector.auto_discovered_async" class="Http\HttplugBundle\Collector\ProfileClient" decorates="httplug.auto_discovery.auto_discovered_async" public="false">
             <argument type="service" id="httplug.collector.auto_discovered_async.inner"/>
             <argument type="service" id="httplug.collector.collector"/>
             <argument type="service" id="httplug.collector.formatter"/>
             <argument type="service" id="debug.stopwatch"/>
-        </service>
-
-        <service id="httplug.auto_discovery.auto_discovered_client.plugin" class="Http\Client\Common\PluginClient" decorates="httplug.auto_discovery.auto_discovered_client" public="false">
-            <argument type="service" id="httplug.auto_discovery.auto_discovered_client.plugin.inner"/>
-            <argument type="collection">
-                <argument type="service">
-                    <service parent="httplug.plugin.stack">
-                        <argument>auto_discovered_client</argument>
-                    </service>
-                </argument>
-            </argument>
-        </service>
-        <service id="httplug.auto_discovery.auto_discovered_async.plugin" class="Http\Client\Common\PluginClient" decorates="httplug.auto_discovery.auto_discovered_async" public="false">
-            <argument type="service" id="httplug.auto_discovery.auto_discovered_async.plugin.inner"/>
-            <argument type="collection">
-                <argument type="service">
-                    <service parent="httplug.plugin.stack">
-                        <argument>auto_discovered_async</argument>
-                    </service>
-                </argument>
-            </argument>
         </service>
 
         <!-- ClientFactories -->

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,14 +18,6 @@
             <factory class="Http\Discovery\HttpAsyncClientDiscovery" method="find" />
         </service>
 
-        <!-- Decorate discovered clients with PluginClient -->
-        <service id="httplug.auto_discovery.auto_discovered_client.plugin" class="Http\Client\Common\PluginClient" decorates="httplug.auto_discovery.auto_discovered_client" decoration-priority="1" public="false">
-            <argument type="service" id="httplug.auto_discovery.auto_discovered_client.plugin.inner"/>
-        </service>
-        <service id="httplug.auto_discovery.auto_discovered_async.plugin" class="Http\Client\Common\PluginClient" decorates="httplug.auto_discovery.auto_discovered_async" decoration-priority="1" public="false">
-            <argument type="service" id="httplug.auto_discovery.auto_discovered_async.plugin.inner"/>
-        </service>
-
         <!-- Discovery with autowiring support for Symfony 3.3+ -->
         <service id="httplug.message_factory.default" class="Http\Message\MessageFactory">
             <factory class="Http\Discovery\MessageFactoryDiscovery" method="find" />

--- a/Tests/Functional/DiscoveredClientsTest.php
+++ b/Tests/Functional/DiscoveredClientsTest.php
@@ -2,13 +2,12 @@
 
 namespace Http\HttplugBundle\Tests\Functional;
 
-use Http\Client\Common\PluginClient;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Discovery\HttpAsyncClientDiscovery;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Strategy\CommonClassesStrategy;
-use Http\HttplugBundle\Collector\StackPlugin;
+use Http\HttplugBundle\Collector\ProfileClient;
 use Http\HttplugBundle\Discovery\ConfiguredClientsStrategy;
 use Nyholm\NSA;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -24,9 +23,7 @@ class DiscoveredClientsTest extends WebTestCase
 
         $service = $container->get('httplug.auto_discovery.auto_discovered_client');
 
-        $this->assertInstanceOf(PluginClient::class, $service);
-        $this->assertInstanceOf(HttpClient::class, NSA::getProperty($service, 'client'));
-        $this->assertEmpty(NSA::getProperty($service, 'plugins'));
+        $this->assertInstanceOf(HttpClient::class, $service);
     }
 
     public function testDiscoveredAsyncClient()
@@ -37,9 +34,7 @@ class DiscoveredClientsTest extends WebTestCase
 
         $service = $container->get('httplug.auto_discovery.auto_discovered_async');
 
-        $this->assertInstanceOf(PluginClient::class, $service);
-        $this->assertInstanceOf(HttpAsyncClient::class, NSA::getProperty($service, 'client'));
-        $this->assertEmpty(NSA::getProperty($service, 'plugins'));
+        $this->assertInstanceOf(HttpAsyncClient::class, $service);
     }
 
     public function testDiscoveredClientWithProfilingEnabled()
@@ -50,13 +45,8 @@ class DiscoveredClientsTest extends WebTestCase
 
         $service = $container->get('httplug.auto_discovery.auto_discovered_client');
 
-        $this->assertInstanceOf(PluginClient::class, $service);
+        $this->assertInstanceOf(ProfileClient::class, $service);
         $this->assertInstanceOf(HttpClient::class, NSA::getProperty($service, 'client'));
-
-        $plugins = NSA::getProperty($service, 'plugins');
-        $this->assertCount(1, $plugins);
-        $this->assertInstanceOf(StackPlugin::class, $plugins[0]);
-        $this->assertEquals('auto_discovered_client', NSA::getProperty($plugins[0], 'client'));
     }
 
     public function testDiscoveredAsyncClientWithProfilingEnabled()
@@ -67,13 +57,8 @@ class DiscoveredClientsTest extends WebTestCase
 
         $service = $container->get('httplug.auto_discovery.auto_discovered_async');
 
-        $this->assertInstanceOf(PluginClient::class, $service);
+        $this->assertInstanceOf(ProfileClient::class, $service);
         $this->assertInstanceOf(HttpAsyncClient::class, NSA::getProperty($service, 'client'));
-
-        $plugins = NSA::getProperty($service, 'plugins');
-        $this->assertCount(1, $plugins);
-        $this->assertInstanceOf(StackPlugin::class, $plugins[0]);
-        $this->assertEquals('auto_discovered_async', NSA::getProperty($plugins[0], 'client'));
     }
 
     /**
@@ -92,9 +77,9 @@ class DiscoveredClientsTest extends WebTestCase
         $httpClient = $container->get('httplug.auto_discovery.auto_discovered_client');
         $httpAsyncClient = $container->get('httplug.auto_discovery.auto_discovered_async');
 
-        $this->assertInstanceOf(PluginClient::class, $httpClient);
+        $this->assertInstanceOf(ProfileClient::class, $httpClient);
         $this->assertSame(HttpClientDiscovery::find(), $httpClient);
-        $this->assertInstanceOf(PluginClient::class, $httpAsyncClient);
+        $this->assertInstanceOf(ProfileClient::class, $httpAsyncClient);
         $this->assertSame(HttpAsyncClientDiscovery::find(), $httpAsyncClient);
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #109
| Documentation   | n/a
| License         | MIT

This remove the need of a `PluginClient` for discovered clients. Only a `ProfileClient` is used.

This will help to avoid double profiling I'm talking about in #109.

This also contains a commit to make StyleCI happy because it now requires a blank line before `break` instructions.