### PR TITLE
minor profiler updates

### DIFF
--- a/Collector/Collector.php
+++ b/Collector/Collector.php
@@ -132,7 +132,7 @@ class Collector extends DataCollector
     public function getClients()
     {
         $stacks = array_filter($this->data['stacks'], function (Stack $stack) {
-            return $stack->getParent() == null;
+            return $stack->getParent() === null;
         });
 
         return array_unique(array_map(function (Stack $stack) {

--- a/Resources/views/webprofiler.html.twig
+++ b/Resources/views/webprofiler.html.twig
@@ -71,14 +71,14 @@
     <div class="sf-tabs">
         {% for client in collector.clients %}
         <div class="tab">
-            <h3 class="tab-title">{{ client }} <span class="badge">{{ collector.clientStacks(client)|length }}</span></h3>
+            <h3 class="tab-title">{{ client }} <span class="badge">{{ collector.countClientMessages(client) }}</span></h3>
 
             <div class="tab-content">
                 <p class="help">
                     These messages are sent by client named "{{ client }}".
                 </p>
 
-                {% for stack in collector.clientStacks(client) if not stack.parent %}
+                {% for stack in collector.clientRootStacks(client) %}
                     <div class="httplug-stack">
                         {% include '@Httplug/stack.html.twig' with {
                             'collector': collector,

--- a/Tests/Unit/Collector/CollectorTest.php
+++ b/Tests/Unit/Collector/CollectorTest.php
@@ -66,6 +66,6 @@ class CollectorTest extends \PHPUnit_Framework_TestCase
         $collector->addStack($stack);
 
         $this->assertEquals(['acme'], $collector->getClients());
-        $this->assertEquals([$stack], $collector->getClientStacks('acme'));
+        $this->assertEquals([$stack], $collector->getClientRootStacks('acme'));
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #109
| Documentation   | n/a
| License         | MIT

This is part of #109 and solve some edge cases when displaying the profiler panel:

* don't display empty client tabs in profiler. This happen when the discovery is only used by a third party library.
* return only collector root stacks. This improve template readability.
* better count of client messages. When discovery is forced to a configured client, the message count in the client tab is wrong. This introduce a different way to count messages starting by root stacks and going down to nested requests.