### PR TITLE
Add PluginClientFactory support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
 
 before_install:
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+    - if [ "$DEPENDENCIES" = "dev" ]; then sed -i '/prefer-stable/d' composer.json; fi;
     - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
     - if [ $COVERAGE != true ]; then phpenv config-rm xdebug.ini; fi;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## Unreleased
 
+### Added
+
+- Any third party library using `Http\Client\Common\PluginClientFactory` to create `Http\Client\Common\PluginClient`
+instances now gets zero config profiling.
+- `Http\Client\Common\PluginClientFactory` factory service.
+
+### Changed
+
+- `ProfilePlugin` and `StackPlugin` are no longer registered as (private) services decorators. Those decorators are now
+created through the `Http\HttplugBundle\Collector\PluginClientFactory`.
+
 ### Deprecated
 
 - The `Http\HttplugBundle\ClientFactory\PluginClientFactory` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## Unreleased
+
+### Deprecated
+
+- The `Http\HttplugBundle\ClientFactory\PluginClientFactory` class.
+
 ## 1.7.1 - 2017-08-04
 
 ### Fixed

--- a/ClientFactory/PluginClientFactory.php
+++ b/ClientFactory/PluginClientFactory.php
@@ -2,13 +2,15 @@
 
 namespace Http\HttplugBundle\ClientFactory;
 
-@trigger_error('The '.__NAMESPACE__.'\PluginClientFactory class is deprecated since version 1.8 and will be removed in 2.0.', E_USER_DEPRECATED);
+@trigger_error('The '.__NAMESPACE__.'\PluginClientFactory class is deprecated since version 1.8 and will be removed in 2.0. Use Http\Client\Common\PluginClientFactory instead.', E_USER_DEPRECATED);
 
 use Http\Client\Common\Plugin;
 use Http\Client\Common\PluginClient;
 
 /**
  * This factory creates a PluginClient.
+ *
+ * @deprecated
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */

--- a/ClientFactory/PluginClientFactory.php
+++ b/ClientFactory/PluginClientFactory.php
@@ -2,6 +2,8 @@
 
 namespace Http\HttplugBundle\ClientFactory;
 
+@trigger_error('The '.__NAMESPACE__.'\PluginClientFactory class is deprecated since version 1.8 and will be removed in 2.0.', E_USER_DEPRECATED);
+
 use Http\Client\Common\Plugin;
 use Http\Client\Common\PluginClient;
 

--- a/Collector/PluginClientFactory.php
+++ b/Collector/PluginClientFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Http\HttplugBundle\Collector;
+
+use Http\Client\Common\Plugin;
+use Http\Client\Common\PluginClient;
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+final class PluginClientFactory
+{
+    /**
+     * @var Collector
+     */
+    private $collector;
+
+    /**
+     * @var Formatter
+     */
+    private $formatter;
+
+    /**
+     * @var Stopwatch
+     */
+    private $stopwatch;
+
+    /**
+     * @param Collector $collector
+     * @param Formatter $formatter
+     * @param Stopwatch $stopwatch
+     */
+    public function __construct(Collector $collector, Formatter $formatter, Stopwatch $stopwatch)
+    {
+        $this->collector = $collector;
+        $this->formatter = $formatter;
+        $this->stopwatch = $stopwatch;
+    }
+
+    /**
+     * @param HttpClient|HttpAsyncClient $client
+     * @param Plugin[]                   $plugins
+     * @param array                      $options {
+     *
+     *     @var string $client_name to give client a name which may be used when displaying client information  like in
+     *         the HTTPlugBundle profiler.
+     * }
+     *
+     * @see PluginClient constructor for PluginClient specific $options.
+     *
+     * @return PluginClient
+     */
+    public function createClient($client, array $plugins = [], array $options = [])
+    {
+        $plugins = array_map(function (Plugin $plugin) {
+            return new ProfilePlugin($plugin, $this->collector, $this->formatter);
+        }, $plugins);
+
+        $clientName = isset($options['client_name']) ? $options['client_name'] : 'Default';
+        array_unshift($plugins, new StackPlugin($this->collector, $this->formatter, $clientName));
+        unset($options['client_name']);
+
+        if (!$client instanceof ProfileClient) {
+            $client = new ProfileClient($client, $this->collector, $this->formatter, $this->stopwatch);
+        }
+
+        return new PluginClient($client, $plugins, $options);
+    }
+}

--- a/Collector/PluginClientFactory.php
+++ b/Collector/PluginClientFactory.php
@@ -8,6 +8,14 @@ use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Symfony\Component\Stopwatch\Stopwatch;
 
+/**
+ * This factory is used as a replacement for Http\Client\Common\PluginClientFactory when profiling is enabled. It create
+ * PluginClient instances with all profiling decorators and extra plugins.
+ *
+ * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ *
+ * @internal
+ */
 final class PluginClientFactory
 {
     /**

--- a/Collector/PluginClientFactory.php
+++ b/Collector/PluginClientFactory.php
@@ -9,8 +9,8 @@ use Http\Client\HttpClient;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
- * This factory is used as a replacement for Http\Client\Common\PluginClientFactory when profiling is enabled. It create
- * PluginClient instances with all profiling decorators and extra plugins.
+ * This factory is used as a replacement for Http\Client\Common\PluginClientFactory when profiling is enabled. It
+ * creates PluginClient instances with all profiling decorators and extra plugins.
  *
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  *

--- a/Collector/PluginClientFactoryListener.php
+++ b/Collector/PluginClientFactoryListener.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *
  * @internal
  */
-final class PluginClientFactorySubscriber implements EventSubscriberInterface
+final class PluginClientFactoryListener implements EventSubscriberInterface
 {
     /**
      * @var CollectorPluginClientFactory

--- a/Collector/PluginClientFactorySubscriber.php
+++ b/Collector/PluginClientFactorySubscriber.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Http\HttplugBundle\Collector;
+
+use Http\Client\Common\PluginClientFactory;
+use Http\HttplugBundle\Collector\PluginClientFactory as CollectorPluginClientFactory;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class PluginClientFactorySubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var CollectorPluginClientFactory
+     */
+    private $factory;
+
+    /**
+     * @param CollectorPluginClientFactory $factory
+     */
+    public function __construct(CollectorPluginClientFactory $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * Make sure to profile clients created using PluginClientFactory.
+     *
+     * @param Event $e
+     */
+    public function onEvent(Event $e)
+    {
+        PluginClientFactory::setFactory([$this->factory, 'createClient']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            'kernel.request' => ['onEvent', 1024],
+            'console.command' => ['onEvent', 1024],
+        ];
+    }
+}

--- a/Collector/PluginClientFactorySubscriber.php
+++ b/Collector/PluginClientFactorySubscriber.php
@@ -8,8 +8,8 @@ use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * This subscriber ensure that every PluginClient created when using Http\Client\Common\PluginClientFactory without
- * using the Symfony dependency injection container use the Http\HttplugBundle\Collector\PluginClientFactory factory
+ * This subscriber ensures that every PluginClient created when using Http\Client\Common\PluginClientFactory without
+ * using the Symfony dependency injection container uses the Http\HttplugBundle\Collector\PluginClientFactory factory
  * when profiling is enabled. This allows 0 config profiling of third party libraries which use HTTPlug.
  *
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>

--- a/Collector/PluginClientFactorySubscriber.php
+++ b/Collector/PluginClientFactorySubscriber.php
@@ -7,6 +7,15 @@ use Http\HttplugBundle\Collector\PluginClientFactory as CollectorPluginClientFac
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * This subscriber ensure that every PluginClient created when using Http\Client\Common\PluginClientFactory without
+ * using the Symfony dependency injection container use the Http\HttplugBundle\Collector\PluginClientFactory factory
+ * when profiling is enabled. This allows 0 config profiling of third party libraries which use HTTPlug.
+ *
+ * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ *
+ * @internal
+ */
 final class PluginClientFactorySubscriber implements EventSubscriberInterface
 {
     /**

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -302,6 +302,9 @@ class HttplugExtension extends Extension
                     $plugins
                 )
             )
+            ->addArgument([
+                'client_name' => $clientName,
+            ])
         ;
 
         /*

--- a/Resources/config/data-collector.xml
+++ b/Resources/config/data-collector.xml
@@ -91,7 +91,7 @@
             <argument type="service" id="debug.stopwatch"/>
         </service>
 
-        <service id="httplug.collector.plugin_client_factory_subscriber" class="Http\HttplugBundle\Collector\PluginClientFactorySubscriber">
+        <service id="Http\HttplugBundle\Collector\PluginClientFactoryListener" class="Http\HttplugBundle\Collector\PluginClientFactoryListener">
             <argument type="service" id="Http\Client\Common\PluginClientFactory" />
 
             <tag name="kernel.event_subscriber" />

--- a/Resources/config/data-collector.xml
+++ b/Resources/config/data-collector.xml
@@ -84,5 +84,17 @@
             <argument type="service" id="httplug.collector.formatter"/>
             <argument type="service" id="debug.stopwatch"/>
         </service>
+
+        <service id="Http\Client\Common\PluginClientFactory" class="Http\HttplugBundle\Collector\PluginClientFactory" public="false">
+            <argument type="service" id="httplug.collector.collector"/>
+            <argument type="service" id="httplug.collector.formatter"/>
+            <argument type="service" id="debug.stopwatch"/>
+        </service>
+
+        <service id="httplug.collector.plugin_client_factory_subscriber" class="Http\HttplugBundle\Collector\PluginClientFactorySubscriber">
+            <argument type="service" id="Http\Client\Common\PluginClientFactory" />
+
+            <tag name="kernel.event_subscriber" />
+        </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -44,6 +44,9 @@
         </service>
         <service id="Http\Client\HttpClient" alias="httplug.client" public="false" />
 
+        <!-- PluginClientFactory -->
+        <service id="Http\Client\Common\PluginClientFactory" class="Http\Client\Common\PluginClientFactory" public="false" />
+
         <!-- ClientFactories -->
         <service id="httplug.factory.auto" class="Http\HttplugBundle\ClientFactory\AutoDiscoveryFactory" public="false" />
         <service id="httplug.factory.buzz" class="Http\HttplugBundle\ClientFactory\BuzzFactory" public="false">

--- a/Tests/Functional/ServiceInstantiationTest.php
+++ b/Tests/Functional/ServiceInstantiationTest.php
@@ -82,15 +82,15 @@ class ServiceInstantiationTest extends WebTestCase
      */
     protected static function bootKernel(array $options = [])
     {
-        $kernel = parent::bootKernel($options);
+        parent::bootKernel($options);
 
         /** @var EventDispatcherInterface $dispatcher */
-        $dispatcher = $kernel->getContainer()->get('event_dispatcher');
+        $dispatcher = static::$kernel->getContainer()->get('event_dispatcher');
 
-        $event = new GetResponseEvent($kernel, new Request(), HttpKernelInterface::MASTER_REQUEST);
+        $event = new GetResponseEvent(static::$kernel, new Request(), HttpKernelInterface::MASTER_REQUEST);
 
         $dispatcher->dispatch(KernelEvents::REQUEST, $event);
 
-        return $kernel;
+        return static::$kernel;
     }
 }

--- a/Tests/Functional/ServiceInstantiationTest.php
+++ b/Tests/Functional/ServiceInstantiationTest.php
@@ -11,6 +11,11 @@ use Http\HttplugBundle\Collector\ProfilePlugin;
 use Http\HttplugBundle\Collector\StackPlugin;
 use Nyholm\NSA;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 
 class ServiceInstantiationTest extends WebTestCase
@@ -70,5 +75,22 @@ class ServiceInstantiationTest extends WebTestCase
         $this->assertInstanceOf(ProfilePlugin::class, $plugins[2]);
         $this->assertInstanceOf(ProfilePlugin::class, $plugins[3]);
         $this->assertInstanceOf(ProfilePlugin::class, $plugins[4]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected static function bootKernel(array $options = [])
+    {
+        $kernel = parent::bootKernel($options);
+
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = $kernel->getContainer()->get('event_dispatcher');
+
+        $event = new GetResponseEvent($kernel, new Request(), HttpKernelInterface::MASTER_REQUEST);
+
+        $dispatcher->dispatch(KernelEvents::REQUEST, $event);
+
+        return $kernel;
     }
 }

--- a/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Http\HttplugBundle\Tests\Unit\DependencyInjection;
 
 use Http\Client\Common\PluginClient;
+use Http\HttplugBundle\Collector\PluginClientFactoryListener;
 use Http\HttplugBundle\DependencyInjection\HttplugExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Component\DependencyInjection\Reference;
@@ -195,7 +196,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
             ]
         );
 
-        $this->assertContainerBuilderHasService('httplug.collector.plugin_client_factory_subscriber');
+        $this->assertContainerBuilderHasService(PluginClientFactoryListener::class);
     }
 
     public function testOverrideProfillingFormatter()

--- a/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -116,15 +116,14 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         ]);
 
         $plugins = [
-            'httplug.client.acme.plugin.stack',
-            'httplug.client.acme.plugin.decoder.debug',
-            'httplug.plugin.redirect.debug',
-            'httplug.client.acme.plugin.add_host.debug',
-            'httplug.client.acme.plugin.header_append.debug',
-            'httplug.client.acme.plugin.header_defaults.debug',
-            'httplug.client.acme.plugin.header_set.debug',
-            'httplug.client.acme.plugin.header_remove.debug',
-            'httplug.client.acme.authentication.my_basic.debug',
+            'httplug.client.acme.plugin.decoder',
+            'httplug.plugin.redirect',
+            'httplug.client.acme.plugin.add_host',
+            'httplug.client.acme.plugin.header_append',
+            'httplug.client.acme.plugin.header_defaults',
+            'httplug.client.acme.plugin.header_set',
+            'httplug.client.acme.plugin.header_remove',
+            'httplug.client.acme.authentication.my_basic',
         ];
         $pluginReferences = array_map(function ($id) {
             return new Reference($id);
@@ -134,7 +133,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         foreach ($plugins as $id) {
             $this->assertContainerBuilderHasService($id);
         }
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('httplug.client.acme', 0, $pluginReferences);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('httplug.client.acme', 1, $pluginReferences);
     }
 
     /**
@@ -196,10 +195,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
             ]
         );
 
-        $def = $this->container->findDefinition('httplug.client');
-        $arguments = $def->getArguments();
-
-        $this->assertTrue(isset($arguments[3]));
+        $this->assertContainerBuilderHasService('httplug.collector.plugin_client_factory_subscriber');
     }
 
     public function testOverrideProfillingFormatter()

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "php-http/message": "^1.4",
         "php-http/discovery": "^1.0",
         "twig/twig": "^1.18 || ^2.0",
-        "symfony/asset": "^2.8 || ^3.0"
+        "symfony/asset": "^2.8 || ^3.0",
+        "symfony/dependency-injection": "^2.8.3 || ^3.0.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.1",

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,8 @@
     "conflict": {
         "php-http/guzzle6-adapter": "<1.1"
     },
+    "minimum-stability": "dev",
+    "prefer-dist": true,
     "autoload": {
         "psr-4": {
             "Http\\HttplugBundle\\": ""
@@ -71,7 +73,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.7-dev"
+            "dev-master": "1.8-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "php-http/guzzle6-adapter": "<1.1"
     },
     "minimum-stability": "dev",
-    "prefer-dist": true,
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Http\\HttplugBundle\\": ""

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^5.5 || ^7.0",
         "php-http/client-implementation": "^1.0",
         "php-http/message-factory": "^1.0.2",
-        "php-http/client-common": "^1.2",
+        "php-http/client-common": "^1.6",
         "php-http/cache-plugin": "^1.4",
         "php-http/logger-plugin": "^1.0",
         "php-http/stopwatch-plugin": "^1.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #109 
| Documentation   | TODO
| License         | MIT

Here we are! This PR is the journey achievement for 0 config profiling of 3rd party libraries.

It relies on https://github.com/php-http/client-common/pull/83 which will be released with 1.6.0.

In a few words, it uses the `Http\Client\Common\PluginClientFactory::setFactory` internal method to replace the PluginClientFactory internals. By doing so, every 3rd party library which use the  `Http\Client\Common\PluginClientFactory` to create it's client will automatically get profiling when used within a Symfony application.

To be more precise, clients created using the bundle configuration uses the `Http\Client\Common\PluginClientFactory` service as a DI factory which is replaced by an instance of `Http\HttplugBundle\Collector\PluginClientFactory` when profiling is enabled. Using the collector version of the `PluginClientFactory` make all clients and plugins decorated with appropriate decorators.

The `Http\HttplugBundle\Collector\PluginClientFactorySubscriber` inject the factory callback into `` at early Symfony events like `Http\HttplugBundle\Discovery\ConfiguredClientsStrategy`.

I still have to work on code comments and documentation, I open this pull request to get your feedback.



#### To Do

- [x] Deprecate the `Http\HttplugBundle\ClientFactory\PluginClientFactory` class.
- [x] Changelog.
- [ ] Documentation.
- [x] Code comments.
- [x] Rebase code when #200 and #201 gets merged.
