### PR TITLE
Make sure we use different cache directories every time we run the tests

### DIFF
--- a/Tests/Resources/app/AppKernel.php
+++ b/Tests/Resources/app/AppKernel.php
@@ -12,6 +12,11 @@ class AppKernel extends Kernel
     use MicroKernelTrait;
 
     /**
+     * @var string
+     */
+    private static $cachePrefix;
+
+    /**
      * {@inheritdoc}
      */
     public function registerBundles()
@@ -55,7 +60,10 @@ class AppKernel extends Kernel
      */
     public function getCacheDir()
     {
-        return sys_get_temp_dir().'/httplug-bundle/cache';
+        if (null === self::$cachePrefix) {
+            self::$cachePrefix = uniqid('cache');
+        }
+        return sys_get_temp_dir().'/httplug-bundle/'.self::$cachePrefix;
     }
 
     /**

--- a/Tests/Resources/app/AppKernel.php
+++ b/Tests/Resources/app/AppKernel.php
@@ -14,7 +14,7 @@ class AppKernel extends Kernel
     /**
      * @var string
      */
-    private static $cachePrefix;
+    private static $cacheDir;
 
     /**
      * {@inheritdoc}
@@ -60,10 +60,10 @@ class AppKernel extends Kernel
      */
     public function getCacheDir()
     {
-        if (null === self::$cachePrefix) {
-            self::$cachePrefix = uniqid('cache');
+        if (null === self::$cacheDir) {
+            self::$cacheDir = uniqid('cache');
         }
-        return sys_get_temp_dir().'/httplug-bundle/'.self::$cachePrefix;
+        return sys_get_temp_dir().'/httplug-bundle/'.self::$cacheDir;
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes, kind of
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

When you run the tests you build some cache in your system's temp directory. If you say, bump some versions that cache may not be properly cleared. This fix make sure we always start with a clear cache every time we run the tests. 
