### PR TITLE
Add autowiring for RequestFactory and ResponseFactory

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -23,6 +23,8 @@
             <factory class="Http\Discovery\MessageFactoryDiscovery" method="find" />
         </service>
         <service id="Http\Message\MessageFactory" alias="httplug.message_factory" public="false" />
+        <service id="Http\Message\RequestFactory" alias="httplug.message_factory" public="false" />
+        <service id="Http\Message\ResponseFactory" alias="httplug.message_factory" public="false" />
 
         <service id="httplug.stream_factory.default" class="Http\Message\StreamFactory">
             <factory class="Http\Discovery\StreamFactoryDiscovery" method="find" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | in/a
| License         | MIT


#### What's in this PR?

MessageFactory has 2 parent interfaces (allowing to typehint against only the part you want). This makes these interfaces work for autowiring too (by using the existing message_factory service, as it implements these interfaces due to this inheritance)


#### Why?

Autowiring is great, and the bundle should make it work fine.

