### PR TITLE
Add reset method to collector

### DIFF
--- a/Collector/Collector.php
+++ b/Collector/Collector.php
@@ -27,7 +27,7 @@ class Collector extends DataCollector
 
     public function __construct()
     {
-        $this->data['stacks'] = [];
+        $this->reset();
     }
 
     /**
@@ -36,6 +36,15 @@ class Collector extends DataCollector
     public function collect(Request $request, Response $response, Exception $exception = null)
     {
         // We do not need to collect any data from the Symfony Request and Response
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data['stacks'] = [];
+        $this->activeStack = null;
     }
 
     /**

--- a/Tests/Unit/Collector/CollectorTest.php
+++ b/Tests/Unit/Collector/CollectorTest.php
@@ -69,4 +69,18 @@ class CollectorTest extends TestCase
         $this->assertEquals(['acme'], $collector->getClients());
         $this->assertEquals([$stack], $collector->getClientRootStacks('acme'));
     }
+
+    public function testResetAction()
+    {
+        $stack = new Stack('acme', 'GET / HTTP/1.1');
+
+        $collector = new Collector();
+        $collector->addStack($stack);
+        $collector->activateStack($stack);
+
+        $collector->reset();
+
+        $this->assertNull($collector->getActiveStack());
+        $this->assertEmpty($collector->getStacks());
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #215 
| Documentation   | n/a
| License         | MIT

This implement the `DataCollectorInterface::reset` method which will be required to get his bundle working with Symfony 4.