### PR TITLE
[CachePlugin] added missing service reference for cache_key_generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ created through the `Http\HttplugBundle\Collector\PluginClientFactory`.
 
 - The `Http\HttplugBundle\ClientFactory\PluginClientFactory` class.
 
+### Fixed
+
+- Added missing service reference for `CachePlugin`'s `cache_key_generator` configuration option. 
+
 ## 1.7.1 - 2017-08-04
 
 ### Fixed

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -144,11 +144,15 @@ class HttplugExtension extends Extension
     {
         switch ($name) {
             case 'cache':
+                $options = $config['config'];
+                if (!empty($options['cache_key_generator'])) {
+                    $options['cache_key_generator'] = new Reference($options['cache_key_generator']);
+                }
+
                 $definition
                     ->replaceArgument(0, new Reference($config['cache_pool']))
                     ->replaceArgument(1, new Reference($config['stream_factory']))
-                    ->replaceArgument(2, $config['config']);
-
+                    ->replaceArgument(2, $options);
                 break;
             case 'cookie':
                 $definition->replaceArgument(0, new Reference($config['cookie_jar']));

--- a/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -2,7 +2,6 @@
 
 namespace Http\HttplugBundle\Tests\Unit\DependencyInjection;
 
-use Http\Client\Common\PluginClient;
 use Http\HttplugBundle\Collector\PluginClientFactoryListener;
 use Http\HttplugBundle\DependencyInjection\HttplugExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
@@ -211,6 +210,27 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
 
         $def = $this->container->findDefinition('httplug.collector.formatter');
         $this->assertEquals('acme.formatter', (string) $def->getArgument(0));
+    }
+
+    public function testCachePluginConfigCacheKeyGeneratorReference()
+    {
+        $this->load([
+            'plugins' => [
+                'cache' => [
+                    'cache_pool' => 'my_cache_pool',
+                    'config' => [
+                        'cache_key_generator' => 'header_cache_key_generator',
+                    ],
+                ],
+            ],
+        ]);
+
+        $cachePlugin = $this->container->findDefinition('httplug.plugin.cache');
+
+        $config = $cachePlugin->getArgument(2);
+        $this->assertArrayHasKey('cache_key_generator', $config);
+        $this->assertInstanceOf(Reference::class, $config['cache_key_generator']);
+        $this->assertSame('header_cache_key_generator', (string) $config['cache_key_generator']);
     }
 
     private function verifyProfilingDisabled()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | https://github.com/php-http/documentation/pull/215
| License         | MIT


#### What's in this PR?

Added missing service reference for `CachePlugin`'s `cache_key_generator` configuration option.


#### Why?

Your are able to replace the default CacheKeyGenerator-Strategy.


#### Checklist

- [X] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix




