### PR TITLE
remove stability settings from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,6 @@
     "conflict": {
         "php-http/guzzle6-adapter": "<1.1"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Http\\HttplugBundle\\": ""


### PR DESCRIPTION
With `prefer-stable` set to `true`, the `DEPENDECIES=dev` build job
will (almost) never install not yet released dependencies. Without
the `prefer-stable` setting we should also drop the `minimum-stability`
setting (which is now useless as the config value is set in the Travis
job).