### PR TITLE
turn off unneeded noise in tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,10 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          syntaxCheck="true">
+    <php>
+        <env name="SHELL_VERBOSITY" value="-1" />
+    </php>
+
     <testsuites>
         <testsuite name="HttplugBundle unit tests">
             <directory suffix="Test.php">./Tests/Unit</directory>


### PR DESCRIPTION
There is no need to log all notices when running tests. Seeing just critical errors is sufficient.