### PR TITLE
update the list of required dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,40 +17,45 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
-        "php-http/client-implementation": "^1.0",
-        "php-http/message-factory": "^1.0.2",
         "php-http/client-common": "^1.6",
+        "php-http/client-implementation": "^1.0",
         "php-http/cache-plugin": "^1.4",
-        "php-http/logger-plugin": "^1.0",
-        "php-http/stopwatch-plugin": "^1.0",
-        "symfony/options-resolver": "^2.8 || ^3.0 || ^4.0",
-        "symfony/event-dispatcher": "^2.8 || ^3.0 || ^4.0",
-        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",
-        "php-http/message": "^1.4",
         "php-http/discovery": "^1.0",
-        "twig/twig": "^1.18 || ^2.0",
+        "php-http/httplug": "^1.0",
+        "php-http/logger-plugin": "^1.0",
+        "php-http/message": "^1.4",
+        "php-http/message-factory": "^1.0.2",
+        "php-http/stopwatch-plugin": "^1.0",
+        "psr/http-message": "^1.0",
         "symfony/asset": "^2.8 || ^3.0 || ^4.0",
-        "symfony/dependency-injection": "^2.8.3 || ^3.0.3 || ^4.0"
+        "symfony/config": "^2.8 || ^3.0 || ^4.0",
+        "symfony/dependency-injection": "^2.8.3 || ^3.0.3 || ^4.0",
+        "symfony/event-dispatcher": "^2.8 || ^3.0 || ^4.0",
+        "symfony/http-kernel": "^2.8 || ^3.0 || ^4.0",
+        "symfony/options-resolver": "^2.8 || ^3.0 || ^4.0",
+        "twig/twig": "^1.18 || ^2.0"
     },
     "require-dev": {
-        "phpunit/php-token-stream": "^1.1.8",
-        "php-http/curl-client": "^1.0",
-        "php-http/socket-client": "^1.0",
-        "php-http/guzzle6-adapter": "^1.1.1",
-        "php-http/react-adapter": "^0.2.1",
-        "php-http/buzz-adapter": "^0.3",
-        "php-http/mock-client": "^1.0",
-        "symfony/phpunit-bridge": "^3.3 || ^4.0",
-        "symfony/twig-bundle": "^2.8 || ^3.0 || ^4.0",
-        "symfony/twig-bridge": "^2.8 || ^3.0 || ^4.0",
-        "symfony/web-profiler-bundle": "^2.8 || ^3.0 || ^4.0",
-        "symfony/finder": "^2.7 || ^3.0 || ^4.0",
-        "symfony/cache": "^3.1 || ^4.0",
-        "symfony/browser-kit": "^2.8 || ^3.0 || ^4.0",
-        "symfony/dom-crawler": "^2.8 || ^3.0 || ^4.0",
-        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
+        "guzzlehttp/psr7": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.1 || ^2.0",
-        "nyholm/nsa": "^1.1"
+        "nyholm/nsa": "^1.1",
+        "php-http/buzz-adapter": "^0.3",
+        "php-http/curl-client": "^1.0",
+        "php-http/guzzle6-adapter": "^1.1.1",
+        "php-http/mock-client": "^1.0",
+        "php-http/promise": "^1.0",
+        "php-http/react-adapter": "^0.2.1",
+        "php-http/socket-client": "^1.0",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
+        "symfony/browser-kit": "^2.8 || ^3.0 || ^4.0",
+        "symfony/cache": "^3.1 || ^4.0",
+        "symfony/dom-crawler": "^2.8 || ^3.0 || ^4.0",
+        "symfony/framework-bundle": "^2.8.1 || ^3.0.1 || ^4.0",
+        "symfony/http-foundation": "^2.8 || ^3.0 || ^4.0",
+        "symfony/phpunit-bridge": "^3.3 || ^4.0",
+        "symfony/stopwatch": "^2.8 || ^3.0 || ^4.0",
+        "symfony/twig-bundle": "^2.8 || ^3.0 || ^4.0",
+        "symfony/web-profiler-bundle": "^2.8 || ^3.0 || ^4.0"
     },
     "conflict": {
         "php-http/guzzle6-adapter": "<1.1"
@@ -68,6 +73,9 @@
     "scripts": {
         "test": "vendor/bin/simple-phpunit",
         "test-ci": "vendor/bin/simple-phpunit --coverage-text --coverage-clover=build/coverage.xml"
+    },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
To make it easier to see which dependencies are actually required
packages are now sorted. That was not a technical requirement.

* added `symfony/config`, this package is needed by the dependency
  injection extension

* added `symfony/http-kernel` which provides the base `Bundle` class

* added `php-http/httplug` and `psr/http-message` which provide
  interfaces the bundle relies on to be present

* moved `symfony/framework-bundle` to the `require-dev` section, it is
  only needed in tests where the `WebTestCase` class is used for
  functional tests

* added `guzzlehttp/psr7`, `php-http/promise`, `symfony/stopwatch`, and
  `symfony/http-foundation` as dev dependencies

* removed `phpunit/php-token-stream`, `symfony/finder`, and
  `symfony/twig-bridge` from `require-dev`