### PR TITLE
Removed "end year" form the license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2016 PHP HTTP Team <team@php-http.org>
+Copyright (c) 2015 PHP HTTP Team <team@php-http.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This is not needed. You will automatically have copy right for what ever you create for 50(?) years. 