### PR TITLE
Work around same-name import bug in PHP 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
-## Unreleased
+## 1.8.1 - 2017-12-06
+
+### Fixed
+
+- `PluginClientFactory` name conflict with PHP 5.x.
+
+## 1.8.0 - 2017-11-30
 
 ### Added
 

--- a/Collector/PluginClientFactoryListener.php
+++ b/Collector/PluginClientFactoryListener.php
@@ -2,8 +2,7 @@
 
 namespace Http\HttplugBundle\Collector;
 
-use Http\Client\Common\PluginClientFactory;
-use Http\HttplugBundle\Collector\PluginClientFactory as CollectorPluginClientFactory;
+use Http\Client\Common\PluginClientFactory as DefaultPluginClientFactory;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -19,14 +18,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 final class PluginClientFactoryListener implements EventSubscriberInterface
 {
     /**
-     * @var CollectorPluginClientFactory
+     * @var PluginClientFactory
      */
     private $factory;
 
     /**
-     * @param CollectorPluginClientFactory $factory
+     * @param PluginClientFactory $factory
      */
-    public function __construct(CollectorPluginClientFactory $factory)
+    public function __construct(PluginClientFactory $factory)
     {
         $this->factory = $factory;
     }
@@ -38,7 +37,7 @@ final class PluginClientFactoryListener implements EventSubscriberInterface
      */
     public function onEvent(Event $e)
     {
-        PluginClientFactory::setFactory([$this->factory, 'createClient']);
+        DefaultPluginClientFactory::setFactory([$this->factory, 'createClient']);
     }
 
     /**

--- a/Tests/Unit/Collector/PluginClientFactoryListenerTest.php
+++ b/Tests/Unit/Collector/PluginClientFactoryListenerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Http\HttplugBundle\Tests\Unit\Collector;
+
+use Http\Client\Common\PluginClientFactory as DefaultPluginClientFactory;
+use Http\HttplugBundle\Collector\Collector;
+use Http\HttplugBundle\Collector\Formatter;
+use Http\HttplugBundle\Collector\PluginClientFactory;
+use Http\HttplugBundle\Collector\PluginClientFactoryListener;
+use Nyholm\NSA;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+final class PluginClientFactoryListenerTest extends TestCase
+{
+    public function testRegisterPluginClientFactory()
+    {
+        $collector = $this->getMockBuilder(Collector::class)->getMock();
+        $formatter = $this->getMockBuilder(Formatter::class)->disableOriginalConstructor()->getMock();
+        $stopwatch = $this->getMockBuilder(Stopwatch::class)->getMock();
+
+        $factory = new PluginClientFactory($collector, $formatter, $stopwatch);
+
+        $listener = new PluginClientFactoryListener($factory);
+
+        $listener->onEvent(new Event());
+
+        $this->assertTrue(is_callable(NSA::getProperty(DefaultPluginClientFactory::class, 'factory')));
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fix #238
| Documentation   | N/A
| License         | MIT

The bug is fixed in PHP 7.0.7 but not in the 5.6 branch. I'm adding a test to get confirmation it's breaking. Then fix the bug.