### PR TITLE
Add mock client factory for test purpose.

### DIFF
--- a/ClientFactory/MockFactory.php
+++ b/ClientFactory/MockFactory.php
@@ -27,10 +27,14 @@ class MockFactory implements ClientFactory
      */
     public function createClient(array $config = [])
     {
-        if (!class_exists('Http\Mock\Client')) {
+        if (!class_exists(Client::class)) {
             throw new \LogicException('To use the mock adapter you need to install the "php-http/mock-client" package.');
         }
 
-        return $this->client ?: new Client();
+        if (!$this->client) {
+            $this->client = new Client();
+        }
+
+        return $this->client;
     }
 }

--- a/ClientFactory/MockFactory.php
+++ b/ClientFactory/MockFactory.php
@@ -5,8 +5,6 @@ namespace Http\HttplugBundle\ClientFactory;
 use Http\Mock\Client;
 
 /**
- * Class Http\HttplugBundle\ClientFactory\MockFactory
- *
  * @author Gary PEGEOT <garypegeot@gmail.com>
  */
 class MockFactory implements ClientFactory

--- a/ClientFactory/MockFactory.php
+++ b/ClientFactory/MockFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Http\HttplugBundle\ClientFactory;
+
+use Http\Mock\Client;
+
+/**
+ * Class Http\HttplugBundle\ClientFactory\MockFactory
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+class MockFactory implements ClientFactory
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @param Client $client
+     */
+    public function setClient(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createClient(array $config = [])
+    {
+        if (!class_exists('Http\Mock\Client')) {
+            throw new \LogicException('To use the mock adapter you need to install the "php-http/mock-client" package.');
+        }
+
+        return $this->client ?: new Client();
+    }
+}

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -106,6 +106,16 @@ class HttplugExtension extends Extension
                 $container->setAlias('httplug.client.default', 'httplug.client.'.$first);
             }
         }
+
+        $mockClass = 'Http\Mock\Client';
+        $mockServiceId = 'httplug.client.mock';
+
+        if (\class_exists($mockClass) && !$container->has($mockServiceId)) {
+            $container->register($mockServiceId, $mockClass)->setPublic($container->getParameter('kernel.debug'));
+
+            $container->findDefinition('httplug.factory.mock')
+                ->addMethodCall('setClient', [new Reference($mockServiceId)]);
+        }
     }
 
     /**

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -41,6 +41,9 @@ class HttplugExtension extends Extension
 
         $loader->load('services.xml');
         $loader->load('plugins.xml');
+        if (\class_exists(MockClient::class)) {
+            $loader->load('mock-client.xml');
+        }
 
         // Register default services
         foreach ($config['classes'] as $service => $class) {
@@ -106,19 +109,6 @@ class HttplugExtension extends Extension
                 // Alias the first client to httplug.client.default
                 $container->setAlias('httplug.client.default', 'httplug.client.'.$first);
             }
-        }
-
-        $mockServiceId = 'httplug.client.mock';
-
-        if (!\class_exists(MockClient::class)) {
-            $container->removeDefinition('httplug.factory.mock');
-        }
-
-        if ($container->has('httplug.factory.mock') && !$container->has($mockServiceId)) {
-            $container->register($mockServiceId, MockClient::class)->setPublic($container->getParameter('kernel.debug'));
-
-            $container->findDefinition('httplug.factory.mock')
-                ->addMethodCall('setClient', [new Reference($mockServiceId)]);
         }
     }
 

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -12,6 +12,7 @@ use Http\Client\HttpClient;
 use Http\Message\Authentication\BasicAuth;
 use Http\Message\Authentication\Bearer;
 use Http\Message\Authentication\Wsse;
+use Http\Mock\Client as MockClient;
 use Psr\Http\Message\UriInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -107,11 +108,14 @@ class HttplugExtension extends Extension
             }
         }
 
-        $mockClass = 'Http\Mock\Client';
         $mockServiceId = 'httplug.client.mock';
 
-        if (\class_exists($mockClass) && !$container->has($mockServiceId)) {
-            $container->register($mockServiceId, $mockClass)->setPublic($container->getParameter('kernel.debug'));
+        if (!\class_exists(MockClient::class)) {
+            $container->removeDefinition('httplug.factory.mock');
+        }
+
+        if ($container->has('httplug.factory.mock') && !$container->has($mockServiceId)) {
+            $container->register($mockServiceId, MockClient::class)->setPublic($container->getParameter('kernel.debug'));
 
             $container->findDefinition('httplug.factory.mock')
                 ->addMethodCall('setClient', [new Reference($mockServiceId)]);

--- a/Resources/config/mock-client.xml
+++ b/Resources/config/mock-client.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="httplug.client.mock" class="Http\Mock\Client" public="true" />
+        <service id="httplug.factory.mock" class="Http\HttplugBundle\ClientFactory\MockFactory" public="false">
+            <call method="setClient">
+                <argument type="service" id="httplug.client.mock" />
+            </call>
+        </service>
+    </services>
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -68,5 +68,6 @@
         <service id="httplug.factory.socket" class="Http\HttplugBundle\ClientFactory\SocketFactory" public="false">
             <argument type="service" id="httplug.message_factory"/>
         </service>
+        <service id="httplug.factory.mock" class="Http\HttplugBundle\ClientFactory\MockFactory" public="false" />
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -68,6 +68,5 @@
         <service id="httplug.factory.socket" class="Http\HttplugBundle\ClientFactory\SocketFactory" public="false">
             <argument type="service" id="httplug.message_factory"/>
         </service>
-        <service id="httplug.factory.mock" class="Http\HttplugBundle\ClientFactory\MockFactory" public="false" />
     </services>
 </container>

--- a/Tests/Unit/ClientFactory/MockFactoryTest.php
+++ b/Tests/Unit/ClientFactory/MockFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the HttplugBundle package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Http\HttplugBundle\Tests\Unit\ClientFactory;
+
+use Http\HttplugBundle\ClientFactory\MockFactory;
+use Http\Mock\Client;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+class MockFactoryTest extends TestCase
+{
+    public function testCreateClient()
+    {
+        $factory = new MockFactory();
+        $client = $factory->createClient();
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        $client = new Client();
+
+        $factory->setClient($client);
+
+        $this->assertEquals($client, $factory->createClient());
+    }
+}

--- a/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -134,6 +134,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
             $this->assertContainerBuilderHasService($id);
         }
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('httplug.client.acme', 1, $pluginReferences);
+        $this->assertContainerBuilderHasService('httplug.client.mock');
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,9 @@
     "conflict": {
         "php-http/guzzle6-adapter": "<1.1"
     },
+    "suggest": {
+        "php-http/mock-client": "Add this to your require-dev section to mock HTTP responses easily"
+    },
     "autoload": {
         "psr-4": {
             "Http\\HttplugBundle\\": ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes partially #212 
| Documentation   | https://github.com/php-http/documentation/pull/220
| License         | MIT


#### What's in this PR?

Add a mock client factory to ease functional testing.

#### Example Usage
Configuration:
```yaml
    # config_test.yml
    httplug:
        clients:
            my_awesome_client:
                factory: 'httplug.factory.mock' # replace factory
```
Usage:
``` php
$client = static::createClient();
// $client->disableReboot(); You might uncomment this if your client (BrowserKit) make multiple requests as kernel is rebooted on each request.

$response = $this->createMock('Psr\Http\Message\ResponseInterface');
$response->method('getBody')->willReturn(/* Psr\Http\Message\Interface instance containing expected response content. */);
$client->getContainer()->get('httplug.client.mock')->addResponse($response);
```

