### PR TITLE
Don't remove abstract plugins

### DIFF
--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -127,8 +127,6 @@ class HttplugExtension extends Extension
             if ($this->isConfigEnabled($container, $pluginConfig)) {
                 $def = $container->getDefinition($pluginId);
                 $this->configurePluginByName($name, $def, $pluginConfig, $container, $pluginId);
-            } else {
-                $container->removeDefinition($pluginId);
             }
         }
     }

--- a/Tests/Resources/Fixtures/config/cache_config_with_no_pool.yml
+++ b/Tests/Resources/Fixtures/config/cache_config_with_no_pool.yml
@@ -1,0 +1,3 @@
+httplug:
+    plugins:
+        cache: ~

--- a/Tests/Resources/Fixtures/config/client_cache_config_with_no_pool.yml
+++ b/Tests/Resources/Fixtures/config/client_cache_config_with_no_pool.yml
@@ -1,0 +1,5 @@
+httplug:
+    clients:
+        test:
+            plugins:
+                - cache: ~

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -355,4 +355,24 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $file = __DIR__.'/../../Resources/Fixtures/config/bc/profiling_toolbar.yml';
         $this->assertProcessedConfigurationEquals([], [$file]);
     }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage The child node "cache_pool" at path "httplug.clients.test.plugins.0.cache" must be configured.
+     */
+    public function testClientCacheConfigMustHavePool()
+    {
+        $file = __DIR__.'/../../Resources/Fixtures/config/client_cache_config_with_no_pool.yml';
+        $this->assertProcessedConfigurationEquals([], [$file]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage The child node "cache_pool" at path "httplug.plugins.cache" must be configured.
+     */
+    public function testCacheConfigMustHavePool()
+    {
+        $file = __DIR__.'/../../Resources/Fixtures/config/cache_config_with_no_pool.yml';
+        $this->assertProcessedConfigurationEquals([], [$file]);
+    }
 }

--- a/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -110,6 +110,11 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
                                 ],
                             ],
                         ],
+                        [
+                            'cache' => [
+                                'cache_pool' => 'my_cache_pool',
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -124,6 +129,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
             'httplug.client.acme.plugin.header_set',
             'httplug.client.acme.plugin.header_remove',
             'httplug.client.acme.authentication.my_basic',
+            'httplug.client.acme.plugin.cache',
         ];
         $pluginReferences = array_map(function ($id) {
             return new Reference($id);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #244 
| License         | MIT

These abstract definitions are needed for client plugin definitions, even if plugins weren't configured at root level.

Allows to configure plugin this way

``` yaml
httplug:
    clients:
        test:
            plugins:
                - cache:
                    cache_pool: my_cache_pool

```
instead of forcing unneeded configuration at httplug.plugins.cache level. See linked issue.
