### PR TITLE
Empty configuration should not contain any data.

### DIFF
--- a/Tests/Resources/Fixtures/config/empty.yml
+++ b/Tests/Resources/Fixtures/config/empty.yml
@@ -1,1 +1,0 @@
-httplug:


### PR DESCRIPTION
This will fix our broken master. 

Related to https://github.com/symfony/symfony/pull/25891