### PR TITLE
Make main aliases public

### DIFF
--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -15,6 +15,7 @@ use Http\Message\Authentication\Wsse;
 use Http\Mock\Client as MockClient;
 use Psr\Http\Message\UriInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -54,7 +55,7 @@ class HttplugExtension extends Extension
 
         // Set main aliases
         foreach ($config['main_alias'] as $type => $id) {
-            $container->setAlias(sprintf('httplug.%s', $type), $id);
+            $container->setAlias(sprintf('httplug.%s', $type), new Alias($id, true));
         }
 
         // Configure toolbar


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

Symfony 3.4+ is making services private by default, so this requires configuring the visibility explicitly.

#### Why?

This allows keeping `$this->get('httplug.client')` working without deprecation.

For now, I haven't applied this change to the different client services, but it might make sense as well.
