### PR TITLE
Add QueryParam auth plugin support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -522,6 +522,10 @@ class Configuration implements ConfigurationInterface
                                 $this->validateAuthenticationType(['username', 'password'], $config, 'wsse');
 
                                 break;
+                            case 'query_param':
+                                $this->validateAuthenticationType(['params'], $config, 'query_param');
+
+                                break;
                         }
 
                         return $config;
@@ -529,7 +533,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->children()
                     ->enumNode('type')
-                        ->values(['basic', 'bearer', 'wsse', 'service'])
+                        ->values(['basic', 'bearer', 'wsse', 'service', 'query_param'])
                         ->isRequired()
                         ->cannotBeEmpty()
                     ->end()
@@ -537,6 +541,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('password')->end()
                     ->scalarNode('token')->end()
                     ->scalarNode('service')->end()
+                    ->arrayNode('params')->prototype('scalar')->end()
                     ->end()
                 ->end()
             ->end(); // End authentication plugin
@@ -556,6 +561,10 @@ class Configuration implements ConfigurationInterface
     private function validateAuthenticationType(array $expected, array $actual, $authName)
     {
         unset($actual['type']);
+        // Empty array is always provided, even if the config is not filled.
+        if (empty($actual['params'])) {
+            unset($actual['params']);
+        }
         $actual = array_keys($actual);
         sort($actual);
         sort($expected);

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -11,6 +11,7 @@ use Http\Client\Common\PluginClientFactory;
 use Http\Client\HttpClient;
 use Http\Message\Authentication\BasicAuth;
 use Http\Message\Authentication\Bearer;
+use Http\Message\Authentication\QueryParam;
 use Http\Message\Authentication\Wsse;
 use Http\Mock\Client as MockClient;
 use Psr\Http\Message\UriInterface;
@@ -264,6 +265,11 @@ class HttplugExtension extends Extension
                     $container->register($authServiceKey, Wsse::class)
                         ->addArgument($values['username'])
                         ->addArgument($values['password']);
+
+                    break;
+                case 'query_param':
+                    $container->register($authServiceKey, QueryParam::class)
+                        ->addArgument($values['params']);
 
                     break;
                 case 'service':

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -170,6 +170,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                                     'type' => 'basic',
                                     'username' => 'foo',
                                     'password' => 'bar',
+                                    'params' => [],
                                 ],
                             ],
                         ],
@@ -188,19 +189,23 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                         'type' => 'basic',
                         'username' => 'foo',
                         'password' => 'bar',
+                        'params' => [],
                     ],
                     'my_wsse' => [
                         'type' => 'wsse',
                         'username' => 'foo',
                         'password' => 'bar',
+                        'params' => [],
                     ],
                     'my_bearer' => [
                         'type' => 'bearer',
                         'token' => 'foo',
+                        'params' => [],
                     ],
                     'my_service' => [
                         'type' => 'service',
                         'service' => 'my_auth_service',
+                        'params' => [],
                     ],
                 ],
                 'cache' => [


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #265 
| Documentation | https://github.com/php-http/documentation/pull/238
| License         | MIT

#### What's in this PR?

Add missing support for the `QueryParam` auth plugin.

#### Why?

Because there is no reason to not have it. :-D
