### PR TITLE
Use strpos instead of Xpath

### DIFF
--- a/Tests/Functional/ProfilerTest.php
+++ b/Tests/Functional/ProfilerTest.php
@@ -13,10 +13,8 @@ class ProfilerTest extends WebTestCase
         //Browse any page to get a profile
         $client->request('GET', '/');
 
-        $crawler = $client->request('GET', '/_profiler/latest?panel=httplug');
-        $title = $crawler->filterXPath('//*[@id="collector-content"]/h2');
-
-        $this->assertCount(1, $title);
-        $this->assertEquals('HTTPlug', $title->html());
+        $client->request('GET', '/_profiler/latest?panel=httplug');
+        $content = $client->getResponse()->getContent();
+        $this->assertTrue(false !== strpos($content, '<h2>HTTPlug</h2>'));
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #267 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Xpath did not work. I've got no idea why. It might be the big script tag in `#collector-content` that causes issues. 

I spent a good 30 minutes trying with my limited xpath skill without any success. I finally decided to do a simple strpos. 


#### Why?

Because master build is red on travis. 

