### PR TITLE
Use twig.strict_variables: '%kernel.debug%'

### DIFF
--- a/Tests/Resources/app/config/config_debug.yml
+++ b/Tests/Resources/app/config/config_debug.yml
@@ -1,2 +1,5 @@
 framework:
     profiler: ~
+
+twig:
+    strict_variables: '%kernel.debug%'

--- a/Tests/Resources/app/config/config_test.yml
+++ b/Tests/Resources/app/config/config_test.yml
@@ -26,3 +26,6 @@ httplug:
 services:
     app.http.plugin.custom:
         class: Http\Client\Common\Plugin\RedirectPlugin
+
+twig:
+    strict_variables: '%kernel.debug%'


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

This will fix the following deprecation notice: 

```
 8x: Relying on the default value ("false") of the "twig.strict_variables" configuration option is deprecated since Symfony 4.1. You should use "%kernel.debug%" explicitly instead, which will be the new default in 5.0.
    2x in DiscoveredClientsTest::testDiscoveredClient from Http\HttplugBundle\Tests\Functional
    2x in DiscoveredClientsTest::testDiscoveredClientWithProfilingEnabled from Http\HttplugBundle\Tests\Functional
    2x in DiscoveredClientsTest::testDisabledDiscovery from Http\HttplugBundle\Tests\Functional
    2x in DiscoveredClientsTest::testForcedDiscovery from Http\HttplugBundle\Tests\Functional
```