### PR TITLE
Register routes sf 4.1 style

### DIFF
--- a/Tests/Resources/app/AppKernel.php
+++ b/Tests/Resources/app/AppKernel.php
@@ -53,7 +53,14 @@ class AppKernel extends Kernel
     {
         $routes->import('@WebProfilerBundle/Resources/config/routing/wdt.xml', '/_wdt');
         $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml', '/_profiler');
-        $routes->add('/', 'kernel:indexAction');
+
+        // If 4.1
+        if (Kernel::MAJOR_VERSION === 4 && Kernel::MINOR_VERSION >= 1) {
+            $routes->add('/', 'kernel::indexAction');
+        } else {
+            $routes->add('/', 'kernel:indexAction');
+        }
+
     }
 
     /**

--- a/Tests/Resources/app/AppKernel.php
+++ b/Tests/Resources/app/AppKernel.php
@@ -54,13 +54,12 @@ class AppKernel extends Kernel
         $routes->import('@WebProfilerBundle/Resources/config/routing/wdt.xml', '/_wdt');
         $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml', '/_profiler');
 
-        // If 4.1
-        if (Kernel::MAJOR_VERSION === 4 && Kernel::MINOR_VERSION >= 1) {
+        if (Kernel::MAJOR_VERSION < 4 || (Kernel::MAJOR_VERSION === 4 && Kernel::MINOR_VERSION === 0)) {
             $routes->add('/', 'kernel::indexAction');
         } else {
+            // If 4.1+
             $routes->add('/', 'kernel:indexAction');
         }
-
     }
 
     /**

--- a/Tests/Resources/app/AppKernel.php
+++ b/Tests/Resources/app/AppKernel.php
@@ -55,10 +55,10 @@ class AppKernel extends Kernel
         $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml', '/_profiler');
 
         if (Kernel::MAJOR_VERSION < 4 || (Kernel::MAJOR_VERSION === 4 && Kernel::MINOR_VERSION === 0)) {
-            $routes->add('/', 'kernel::indexAction');
+            $routes->add('/', 'kernel:indexAction');
         } else {
             // If 4.1+
-            $routes->add('/', 'kernel:indexAction');
+            $routes->add('/', 'kernel::indexAction');
         }
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Symfony 4.1 has deprecated the single colon syntax when defining routes. 