### PR TITLE
Prepare for psr/http-client, by allowing HTTPlug v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php-http/client-implementation": "^1.0",
         "php-http/cache-plugin": "^1.4",
         "php-http/discovery": "^1.0",
-        "php-http/httplug": "^1.0",
+        "php-http/httplug": "^1.0 || ^2.0",
         "php-http/logger-plugin": "^1.0",
         "php-http/message": "^1.4",
         "php-http/message-factory": "^1.0.2",


### PR DESCRIPTION
According to https://medium.com/php-fig/the-http-client-psr-9c2535132980

This is the only change we need to support HTTPlug 2. 

Blocked by the release of HTTPlug 2. 