### PR TITLE
Every client should have its own Mock instance

### DIFF
--- a/ClientFactory/MockFactory.php
+++ b/ClientFactory/MockFactory.php
@@ -10,19 +10,6 @@ use Http\Mock\Client;
 class MockFactory implements ClientFactory
 {
     /**
-     * @var Client
-     */
-    private $client;
-
-    /**
-     * @param Client $client
-     */
-    public function setClient(Client $client)
-    {
-        $this->client = $client;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function createClient(array $config = [])
@@ -31,10 +18,6 @@ class MockFactory implements ClientFactory
             throw new \LogicException('To use the mock adapter you need to install the "php-http/mock-client" package.');
         }
 
-        if (!$this->client) {
-            $this->client = new Client();
-        }
-
-        return $this->client;
+        return new Client();
     }
 }

--- a/Resources/config/mock-client.xml
+++ b/Resources/config/mock-client.xml
@@ -4,11 +4,6 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="httplug.client.mock" class="Http\Mock\Client" public="true" />
-        <service id="httplug.factory.mock" class="Http\HttplugBundle\ClientFactory\MockFactory" public="false">
-            <call method="setClient">
-                <argument type="service" id="httplug.client.mock" />
-            </call>
-        </service>
+        <service id="httplug.factory.mock" class="Http\HttplugBundle\ClientFactory\MockFactory" public="false" />
     </services>
 </container>

--- a/Tests/Unit/ClientFactory/MockFactoryTest.php
+++ b/Tests/Unit/ClientFactory/MockFactoryTest.php
@@ -23,11 +23,5 @@ class MockFactoryTest extends TestCase
         $client = $factory->createClient();
 
         $this->assertInstanceOf(Client::class, $client);
-
-        $client = new Client();
-
-        $factory->setClient($client);
-
-        $this->assertEquals($client, $factory->createClient());
     }
 }

--- a/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -147,7 +147,31 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
             $this->assertContainerBuilderHasService($id);
         }
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('httplug.client.acme', 1, $pluginReferences);
-        $this->assertContainerBuilderHasService('httplug.client.mock');
+    }
+
+    public function testMocking()
+    {
+        $this->load([
+            'clients' => [
+                'ace' => [
+                    'factory' => 'httplug.factory.mock',
+                ],
+                'acme' => [
+                    'factory' => 'httplug.factory.mock',
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasService('httplug.client.ace');
+        $this->assertContainerBuilderHasService('httplug.client.ace.client');
+
+        $this->assertContainerBuilderHasService('httplug.client.acme');
+        $this->assertContainerBuilderHasService('httplug.client.acme.client');
+
+        $this->assertNotSame(
+            $this->container->get('httplug.client.ace.client'),
+            $this->container->get('httplug.client.acme.client')
+        );
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |no
| New feature?    | yes
| BC breaks?      |yes
| Deprecations?   | no
| License         | MIT

#### What's in this PR?

This PR makes the MockFactory a real factory.

#### Why?

When you have multiple configured clients, and want to mock them in test mode, you can change the factory method to `httplug.factory.mock`. That's awesome. But they all use the same instance of `Http\Mock\Client` which is problematic. 

If you have 1 service that calls 2 http clients after each othere, there is no way of properly configuring things.

This PR makes sure every client gets its own mock instance that you can access by calling `httplug.client.acme.client` (see https://github.com/php-http/HttplugBundle/pull/287)

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
