### PR TITLE
Make underlying http client also public when configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## Unreleased
+
+### Added
+
+- Make underlying http client (`httplug.client.acme.client`) also public when configured
+
 ## 1.13.0 - 2018-11-13
 
 ### Added

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -322,10 +322,10 @@ class HttplugExtension extends Extension
                 ->register($serviceId.'.client', HttpClient::class)
                 ->setFactory([new Reference($arguments['factory']), 'createClient'])
                 ->addArgument($arguments['config'])
-                ->setPublic(false);
+                ->setPublic($arguments['public'] ? true : false);
         } else {
             $container
-                ->setAlias($serviceId.'.client', new Alias($arguments['service'], false));
+                ->setAlias($serviceId.'.client', new Alias($arguments['service'], $arguments['public'] ? true : false));
         }
 
         $definition = $container


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | follow up of https://github.com/php-http/HttplugBundle/pull/280
 Documentation   | not needed
| License         | MIT


#### What's in this PR?

This makes the underlying http client also public when configured. 

#### Why?

Something I didn't add in #280 but need when using mocks. This is needed for https://github.com/php-http/HttplugBundle/pull/286.

#### Checklist

- [x] Updated CHANGELOG.md
- [ ] Documentation: no need to update
