### PR TITLE
Only require Twig when profiler is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 1.15.0 [unreleased]
+
+### Changed
+
+- Removed `twig/twig` dependency
+
 ## 1.14.0
 
 ### Added

--- a/DependencyInjection/HttplugExtension.php
+++ b/DependencyInjection/HttplugExtension.php
@@ -76,6 +76,10 @@ class HttplugExtension extends Extension
                 ->getDefinition('httplug.formatter.full_http_message')
                 ->addArgument($config['profiling']['captured_body_length'])
             ;
+
+            if (!class_exists(\Twig_Environment::class)) {
+                $container->removeDefinition('httplug.collector.twig.http_message');
+            }
         }
 
         $this->configureClients($container, $config);

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
         "symfony/dependency-injection": "^2.8.49 || ^3.0.9 || ^3.1.10 || ^3.2.14 || ^3.3.18 || ^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
         "symfony/event-dispatcher": "^2.8.49 || ^3.0.9 || ^3.1.10 || ^3.2.14 || ^3.3.18 || ^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
         "symfony/http-kernel": "^2.8.49 || ^3.0.9 || ^3.1.10 || ^3.2.14 || ^3.3.18 || ^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "symfony/options-resolver": "^2.8.49 || ^3.0.9 || ^3.1.10 || ^3.2.14 || ^3.3.18 || ^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "twig/twig": "^1.36 || ^2.6"
+        "symfony/options-resolver": "^2.8.49 || ^3.0.9 || ^3.1.10 || ^3.2.14 || ^3.3.18 || ^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.0",
@@ -50,12 +49,14 @@
         "symfony/phpunit-bridge": "^3.4 || ^4.2",
         "symfony/stopwatch": "^2.8.49 || ^3.0.9 || ^3.1.10 || ^3.2.14 || ^3.3.18 || ^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
         "symfony/twig-bundle": "^2.8.49 || ^3.0.9 || ^3.1.10 || ^3.2.14 || ^3.3.18 || ^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "symfony/web-profiler-bundle": "^2.8.49 || ^3.0.9 || ^3.1.10 || ^3.2.14 || ^3.3.18 || ^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1"
+        "symfony/web-profiler-bundle": "^2.8.49 || ^3.0.9 || ^3.1.10 || ^3.2.14 || ^3.3.18 || ^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
+        "twig/twig": "^1.36 || ^2.6"
     },
     "conflict": {
         "php-http/guzzle6-adapter": "<1.1"
     },
     "suggest": {
+        "twig/twig": "Add this to your require-dev section when using the WebProfilerBundle",
         "php-http/mock-client": "Add this to your require-dev section to mock HTTP responses easily"
     },
     "autoload": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | fixes #300
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

Require Twig to be installed when the profiler is enabled. Move `twig/twig` dependency to suggest and `require-dev`

#### Why?

We don't have Twig installed in our project. HTTPlug requires it to be installed.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
