### PR TITLE
don't call getResponse() on RequestExceptionInterface

### DIFF
--- a/Collector/Formatter.php
+++ b/Collector/Formatter.php
@@ -8,7 +8,6 @@ use Http\Client\Exception\TransferException;
 use Http\Message\Formatter as MessageFormatter;
 use Http\Message\Formatter\CurlCommandFormatter;
 use Psr\Http\Client\NetworkExceptionInterface;
-use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -51,7 +50,7 @@ class Formatter implements MessageFormatter
      */
     public function formatException(Exception $exception)
     {
-        if ($exception instanceof HttpException || $exception instanceof RequestExceptionInterface) {
+        if ($exception instanceof HttpException) {
             return $this->formatter->formatResponse($exception->getResponse());
         }
 

--- a/Collector/ProfileClient.php
+++ b/Collector/ProfileClient.php
@@ -8,7 +8,6 @@ use Http\Client\Exception\HttpException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Psr\Http\Client\ClientInterface;
-use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -183,7 +182,7 @@ class ProfileClient implements HttpClient, HttpAsyncClient
      */
     private function collectExceptionInformations(\Exception $exception, StopwatchEvent $event, Stack $stack)
     {
-        if ($exception instanceof HttpException || $exception instanceof RequestExceptionInterface) {
+        if ($exception instanceof HttpException) {
             $this->collectResponseInformations($exception->getResponse(), $event, $stack);
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #304
| Documentation   | 
| License         | MIT