### PR TITLE
support autowire convenience clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## 1.15.0 [unreleased]
 
+### Added
+
+- Autowiring support for FlexibleClient, HttpMethodsClientInterface and
+  BatchClientInterface if they are enabled on the default/first client.
+  (Only available with Httplug 2)
+
 ### Changed
 
 - Removed `twig/twig` dependency


### PR DESCRIPTION
this only happens for the "default" client: the first configured client or the one called default.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #261 
| Documentation   | -
| License         | MIT


#### What's in this PR?

Autowire the convenience clients

#### Why?

This is the expected behaviour. We only autowire them if the default client has the decorators to avoid unexpected random autowiring.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
