### PR TITLE
cache-plugin is not a hard dependency to use this bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 ### Changed
 
 - Removed `twig/twig` dependency
+- Removed hard dependency on `php-http/cache-plugin`. If you want to use the
+  cache plugin, you need to require it in your project.
 
 ## 1.14.0
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -3,6 +3,7 @@
 namespace Http\HttplugBundle\DependencyInjection;
 
 use Http\Client\Common\Plugin\Cache\Generator\CacheKeyGenerator;
+use Http\Client\Common\Plugin\CachePlugin;
 use Http\Client\Common\Plugin\Journal;
 use Http\Message\CookieJar;
 use Http\Message\Formatter;
@@ -700,7 +701,14 @@ class Configuration implements ConfigurationInterface
         $cache = $builder->root('cache');
         $cache
             ->canBeEnabled()
+            ->info('Configure HTTP caching, requires the php-http/cache-plugin package')
             ->addDefaultsIfNotSet()
+            ->validate()
+                ->ifTrue(function ($v) {
+                    return !empty($v['enabled']) && !class_exists(CachePlugin::class);
+                })
+                ->thenInvalid('To use the cache plugin, you need to require php-http/cache-plugin in your project')
+            ->end()
             ->children()
                 ->scalarNode('cache_pool')
                     ->info('This must be a service id to a service implementing '.CacheItemPoolInterface::class)

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "php": "^5.5 || ^7.0",
         "php-http/client-common": "^1.9 || ^2.0",
         "php-http/client-implementation": "^1.0",
-        "php-http/cache-plugin": "^1.6",
         "php-http/discovery": "^1.0",
         "php-http/httplug": "^1.0 || ^2.0",
         "php-http/logger-plugin": "^1.1",
@@ -37,6 +36,7 @@
         "guzzlehttp/psr7": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.1 || ^2.3",
         "nyholm/nsa": "^1.1",
+        "php-http/cache-plugin": "^1.6",
         "php-http/guzzle6-adapter": "^1.1.1 || ^2.0.1",
         "php-http/promise": "^1.0",
         "php-http/mock-client": "^1.2",
@@ -57,6 +57,7 @@
     },
     "suggest": {
         "twig/twig": "Add this to your require-dev section when using the WebProfilerBundle",
+        "php-http/cache-plugin": "To configure clients that cache responses",
         "php-http/mock-client": "Add this to your require-dev section to mock HTTP responses easily"
     },
     "autoload": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | not really
| Deprecations?   | no
| Related tickets | fixes #310 
| Documentation   | https://github.com/php-http/documentation/pull/254
| License         | MIT


#### What's in this PR?

Remove hard dependency on the cache plugin.


#### Why?

When no caching is configured, the bundle does not need that package.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix) => https://github.com/php-http/documentation/pull/254

