### PR TITLE
make classes final for 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 # Version 2
 
 # 2.0.0 - (unreleased)
+
 - Increased min PHP version to 8.1
 - Removed the deprecated `Http\HttplugBundle\ClientFactory\PluginClientFactory`. Use `Http\Client\Common\PluginClientFactory` instead.
 - Fixed a deprecation when creating a `HttpMethodsClient` via `http_methods_client: true`. Only PSR-17 factories are now passed as constructor arguments.
@@ -18,6 +19,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 - Changed the type of `httplug.client.default` to `ClientInterface` instead of `HttpClient`
 - Removed the `DummyClient` interface
 - Removed the `Http\Client\HttpClient` alias use the `Psr\Http\Client\ClientInterface` typehint in your services for autowiring.
+- Changed classes marked as `@final` to be actually `final`. If you extended any of those, instead implement interfaces or decorate the class rather than extending it. Open an issue if you think a class needs to be made non-final to discuss what we should do.
 
 # Version 1
 

--- a/src/ClientFactory/AutoDiscoveryFactory.php
+++ b/src/ClientFactory/AutoDiscoveryFactory.php
@@ -10,10 +10,8 @@ use Http\Discovery\Psr18ClientDiscovery;
  * Use auto discovery to find a HTTP client.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class AutoDiscoveryFactory implements ClientFactory
+final class AutoDiscoveryFactory implements ClientFactory
 {
     public function createClient(array $config = [])
     {

--- a/src/ClientFactory/BuzzFactory.php
+++ b/src/ClientFactory/BuzzFactory.php
@@ -10,10 +10,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class BuzzFactory implements ClientFactory
+final class BuzzFactory implements ClientFactory
 {
     public function __construct(private readonly ResponseFactoryInterface $responseFactory)
     {

--- a/src/ClientFactory/CurlFactory.php
+++ b/src/ClientFactory/CurlFactory.php
@@ -10,10 +10,8 @@ use Psr\Http\Message\StreamFactoryInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class CurlFactory implements ClientFactory
+final class CurlFactory implements ClientFactory
 {
     public function __construct(
         private readonly ResponseFactoryInterface $responseFactory,

--- a/src/ClientFactory/Guzzle6Factory.php
+++ b/src/ClientFactory/Guzzle6Factory.php
@@ -8,10 +8,8 @@ use Http\Adapter\Guzzle6\Client;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class Guzzle6Factory implements ClientFactory
+final class Guzzle6Factory implements ClientFactory
 {
     public function createClient(array $config = [])
     {

--- a/src/ClientFactory/Guzzle7Factory.php
+++ b/src/ClientFactory/Guzzle7Factory.php
@@ -8,10 +8,8 @@ use Http\Adapter\Guzzle7\Client;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class Guzzle7Factory implements ClientFactory
+final class Guzzle7Factory implements ClientFactory
 {
     public function createClient(array $config = [])
     {

--- a/src/ClientFactory/ReactFactory.php
+++ b/src/ClientFactory/ReactFactory.php
@@ -8,10 +8,8 @@ use Http\Adapter\React\Client;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class ReactFactory implements ClientFactory
+final class ReactFactory implements ClientFactory
 {
     public function createClient(array $config = [])
     {

--- a/src/ClientFactory/SocketFactory.php
+++ b/src/ClientFactory/SocketFactory.php
@@ -8,10 +8,8 @@ use Http\Client\Socket\Client;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class SocketFactory implements ClientFactory
+final class SocketFactory implements ClientFactory
 {
     public function createClient(array $config = [])
     {

--- a/src/ClientFactory/SymfonyFactory.php
+++ b/src/ClientFactory/SymfonyFactory.php
@@ -11,10 +11,8 @@ use Symfony\Component\HttpClient\HttplugClient;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class SymfonyFactory implements ClientFactory
+final class SymfonyFactory implements ClientFactory
 {
     public function __construct(
         private readonly ResponseFactoryInterface $responseFactory,

--- a/src/Collector/Collector.php
+++ b/src/Collector/Collector.php
@@ -18,10 +18,8 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  *
  * @internal
- *
- * @final
  */
-class Collector extends DataCollector
+final class Collector extends DataCollector
 {
     private ?Stack $activeStack = null;
 

--- a/src/Collector/Formatter.php
+++ b/src/Collector/Formatter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Http\HttplugBundle\Collector;
 
-use Exception;
 use Http\Client\Exception\HttpException;
 use Http\Client\Exception\TransferException;
 use Http\Message\Formatter as MessageFormatter;
@@ -19,10 +18,8 @@ use Psr\Http\Message\ResponseInterface;
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  *
  * @internal
- *
- * @final
  */
-class Formatter implements MessageFormatter
+final class Formatter implements MessageFormatter
 {
     public function __construct(
         private readonly MessageFormatter $formatter,

--- a/src/Collector/ProfileClient.php
+++ b/src/Collector/ProfileClient.php
@@ -21,10 +21,8 @@ use Symfony\Component\Stopwatch\StopwatchEvent;
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  *
  * @internal
- *
- * @final
  */
-class ProfileClient implements ClientInterface, HttpAsyncClient
+final class ProfileClient implements ClientInterface, HttpAsyncClient
 {
     use VersionBridgeClient;
 

--- a/src/Collector/ProfileClientFactory.php
+++ b/src/Collector/ProfileClientFactory.php
@@ -16,10 +16,8 @@ use Symfony\Component\Stopwatch\Stopwatch;
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  *
  * @internal
- *
- * @final
  */
-class ProfileClientFactory implements ClientFactory
+final class ProfileClientFactory implements ClientFactory
 {
     /**
      * @var ClientFactory|callable

--- a/src/Collector/ProfilePlugin.php
+++ b/src/Collector/ProfilePlugin.php
@@ -15,10 +15,8 @@ use Psr\Http\Message\ResponseInterface;
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  *
  * @internal
- *
- * @final
  */
-class ProfilePlugin implements Plugin
+final class ProfilePlugin implements Plugin
 {
     use Plugin\VersionBridgePlugin;
 

--- a/src/Collector/StackPlugin.php
+++ b/src/Collector/StackPlugin.php
@@ -15,10 +15,8 @@ use Psr\Http\Message\ResponseInterface;
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
  *
  * @internal
- *
- * @final
  */
-class StackPlugin implements Plugin
+final class StackPlugin implements Plugin
 {
     use Plugin\VersionBridgePlugin;
 

--- a/src/Collector/Twig/HttpMessageMarkupExtension.php
+++ b/src/Collector/Twig/HttpMessageMarkupExtension.php
@@ -13,10 +13,8 @@ use Twig\TwigFilter;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class HttpMessageMarkupExtension extends AbstractExtension
+final class HttpMessageMarkupExtension extends AbstractExtension
 {
     private ClonerInterface $cloner;
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -31,10 +31,8 @@ use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
  *
  * @author David Buchmann <mail@davidbu.ch>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     /**
      * Whether to use the debug mode.

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -40,10 +40,8 @@ use Twig\Environment as TwigEnvironment;
 /**
  * @author David Buchmann <mail@davidbu.ch>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class HttplugExtension extends Extension
+final class HttplugExtension extends Extension
 {
     public const HTTPLUG_CLIENT_TAG = 'httplug.client';
 

--- a/src/Discovery/ConfiguredClientsStrategy.php
+++ b/src/Discovery/ConfiguredClientsStrategy.php
@@ -14,10 +14,8 @@ use Psr\Http\Client\ClientInterface;
  * we can use the web debug toolbar for clients found with the discovery.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class ConfiguredClientsStrategy implements DiscoveryStrategy
+final class ConfiguredClientsStrategy implements DiscoveryStrategy
 {
     private static ?ClientInterface $client = null;
 

--- a/src/Discovery/ConfiguredClientsStrategyListener.php
+++ b/src/Discovery/ConfiguredClientsStrategyListener.php
@@ -9,10 +9,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
- *
- * @final
  */
-class ConfiguredClientsStrategyListener implements EventSubscriberInterface
+final class ConfiguredClientsStrategyListener implements EventSubscriberInterface
 {
     /**
      * Make sure to use the custom strategy.

--- a/src/HttplugBundle.php
+++ b/src/HttplugBundle.php
@@ -9,9 +9,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 /**
  * @author David Buchmann <mail@davidbu.ch>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- *
- * @final
  */
-class HttplugBundle extends Bundle
+final class HttplugBundle extends Bundle
 {
 }

--- a/tests/Functional/DiscoveredClientsTest.php
+++ b/tests/Functional/DiscoveredClientsTest.php
@@ -16,7 +16,7 @@ use Nyholm\NSA;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class DiscoveredClientsTest extends WebTestCase
+final class DiscoveredClientsTest extends WebTestCase
 {
     public function testDiscoveredClient(): void
     {

--- a/tests/Functional/Issue206.php
+++ b/tests/Functional/Issue206.php
@@ -11,7 +11,7 @@ use Http\Discovery\Psr18ClientDiscovery;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class Issue206 extends WebTestCase
+final class Issue206 extends WebTestCase
 {
     public function testCustomClientDoesNotCauseException(): void
     {

--- a/tests/Functional/ProfilerTest.php
+++ b/tests/Functional/ProfilerTest.php
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Request;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class ProfilerTest extends WebTestCase
+final class ProfilerTest extends WebTestCase
 {
     /**
      * @group legacy

--- a/tests/Functional/ProfilingTest.php
+++ b/tests/Functional/ProfilingTest.php
@@ -22,7 +22,7 @@ use Psr\Http\Message\RequestInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Stopwatch\Stopwatch;
 
-class ProfilingTest extends TestCase
+final class ProfilingTest extends TestCase
 {
     private Collector $collector;
 

--- a/tests/Functional/ServiceInstantiationTest.php
+++ b/tests/Functional/ServiceInstantiationTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 
-class ServiceInstantiationTest extends WebTestCase
+final class ServiceInstantiationTest extends WebTestCase
 {
     public function testHttpClient(): void
     {

--- a/tests/Unit/ClientFactory/BuzzFactoryTest.php
+++ b/tests/Unit/ClientFactory/BuzzFactoryTest.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ResponseFactoryInterface;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class BuzzFactoryTest extends TestCase
+final class BuzzFactoryTest extends TestCase
 {
     public function testCreateClient(): void
     {

--- a/tests/Unit/ClientFactory/CurlFactoryTest.php
+++ b/tests/Unit/ClientFactory/CurlFactoryTest.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class CurlFactoryTest extends TestCase
+final class CurlFactoryTest extends TestCase
 {
     public function testCreateClient(): void
     {

--- a/tests/Unit/ClientFactory/Guzzle6FactoryTest.php
+++ b/tests/Unit/ClientFactory/Guzzle6FactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class Guzzle6FactoryTest extends TestCase
+final class Guzzle6FactoryTest extends TestCase
 {
     public function testCreateClient(): void
     {

--- a/tests/Unit/ClientFactory/Guzzle7FactoryTest.php
+++ b/tests/Unit/ClientFactory/Guzzle7FactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class Guzzle7FactoryTest extends TestCase
+final class Guzzle7FactoryTest extends TestCase
 {
     public function testCreateClient(): void
     {

--- a/tests/Unit/ClientFactory/MockFactoryTest.php
+++ b/tests/Unit/ClientFactory/MockFactoryTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @author Gary PEGEOT <garypegeot@gmail.com>
  */
-class MockFactoryTest extends TestCase
+final class MockFactoryTest extends TestCase
 {
     public function testCreateClient(): void
     {

--- a/tests/Unit/ClientFactory/ReactFactoryTest.php
+++ b/tests/Unit/ClientFactory/ReactFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class ReactFactoryTest extends TestCase
+final class ReactFactoryTest extends TestCase
 {
     public function testCreateClient(): void
     {

--- a/tests/Unit/ClientFactory/SocketFactoryTest.php
+++ b/tests/Unit/ClientFactory/SocketFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class SocketFactoryTest extends TestCase
+final class SocketFactoryTest extends TestCase
 {
     public function testCreateClient(): void
     {

--- a/tests/Unit/ClientFactory/SymfonyFactoryTest.php
+++ b/tests/Unit/ClientFactory/SymfonyFactoryTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpClient\HttplugClient;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class SymfonyFactoryTest extends TestCase
+final class SymfonyFactoryTest extends TestCase
 {
     public function testCreateClient(): void
     {

--- a/tests/Unit/Collector/CollectorTest.php
+++ b/tests/Unit/Collector/CollectorTest.php
@@ -8,7 +8,7 @@ use Http\HttplugBundle\Collector\Collector;
 use Http\HttplugBundle\Collector\Stack;
 use PHPUnit\Framework\TestCase;
 
-class CollectorTest extends TestCase
+final class CollectorTest extends TestCase
 {
     public function testCollectClientNames(): void
     {

--- a/tests/Unit/Collector/FormatterTest.php
+++ b/tests/Unit/Collector/FormatterTest.php
@@ -15,7 +15,7 @@ use Http\Message\Formatter\SimpleFormatter;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class FormatterTest extends TestCase
+final class FormatterTest extends TestCase
 {
     private MessageFormatter&MockObject $formatter;
 

--- a/tests/Unit/Collector/ProfileClientFactoryTest.php
+++ b/tests/Unit/Collector/ProfileClientFactoryTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
-class ProfileClientFactoryTest extends TestCase
+final class ProfileClientFactoryTest extends TestCase
 {
     private Collector $collector;
 

--- a/tests/Unit/Collector/ProfileClientTest.php
+++ b/tests/Unit/Collector/ProfileClientTest.php
@@ -25,7 +25,7 @@ use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Stopwatch\StopwatchEvent;
 
-class ProfileClientTest extends TestCase
+final class ProfileClientTest extends TestCase
 {
     private Collector $collector;
 

--- a/tests/Unit/Collector/ProfilePluginTest.php
+++ b/tests/Unit/Collector/ProfilePluginTest.php
@@ -17,13 +17,14 @@ use Http\Message\Formatter\SimpleFormatter;
 use Http\Promise\FulfilledPromise;
 use Http\Promise\Promise;
 use Http\Promise\RejectedPromise;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class ProfilePluginTest extends TestCase
+final class ProfilePluginTest extends TestCase
 {
-    private Plugin $plugin;
+    private Plugin&MockObject $plugin;
 
     private RequestInterface $request;
 
@@ -74,7 +75,7 @@ class ProfilePluginTest extends TestCase
         $this->subject = new ProfilePlugin(
             $this->plugin,
             $this->collector,
-            $formatter
+            $formatter,
         );
     }
 

--- a/tests/Unit/Collector/StackPluginTest.php
+++ b/tests/Unit/Collector/StackPluginTest.php
@@ -14,37 +14,21 @@ use Http\Message\Formatter as MessageFormatter;
 use Http\Message\Formatter\SimpleFormatter;
 use Http\Promise\FulfilledPromise;
 use Http\Promise\RejectedPromise;
-use PHPUnit\Framework\Error\Warning;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class StackPluginTest extends TestCase
+final class StackPluginTest extends TestCase
 {
-    /**
-     * @var Collector
-     */
-    private $collector;
+    private Collector $collector;
 
-    /**
-     * @var RequestInterface
-     */
-    private $request;
+    private RequestInterface $request;
 
-    /**
-     * @var ResponseInterface
-     */
-    private $response;
+    private ResponseInterface $response;
 
-    /**
-     * @var \Exception
-     */
-    private $exception;
+    private \Exception $exception;
 
-    /**
-     * @var StackPlugin
-     */
-    private $subject;
+    private StackPlugin $subject;
 
     public function setUp(): void
     {
@@ -128,11 +112,7 @@ class StackPluginTest extends TestCase
 
     public function testOnError(): void
     {
-        if (version_compare(PHP_VERSION, '8.0.0', '>=')) {
-            $this->expectException(\DivisionByZeroError::class);
-        } else {
-            $this->expectException(Warning::class);
-        }
+        $this->expectException(\DivisionByZeroError::class);
 
         $next = fn () => 2 / 0;
 

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 /**
  * @author David Buchmann <mail@davidbu.ch>
  */
-class ConfigurationTest extends AbstractExtensionConfigurationTestCase
+final class ConfigurationTest extends AbstractExtensionConfigurationTestCase
 {
     private array $emptyConfig = [
         'default_client_autowiring' => true,

--- a/tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Reference;
  * @author David Buchmann <mail@davidbu.ch>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class HttplugExtensionTest extends AbstractExtensionTestCase
+final class HttplugExtensionTest extends AbstractExtensionTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Unit/Discovery/ConfiguredClientsStrategyTest.php
+++ b/tests/Unit/Discovery/ConfiguredClientsStrategyTest.php
@@ -9,7 +9,7 @@ use Http\HttplugBundle\Discovery\ConfiguredClientsStrategy;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 
-class ConfiguredClientsStrategyTest extends TestCase
+final class ConfiguredClientsStrategyTest extends TestCase
 {
     public function testGetCandidates(): void
     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | fix #317 
| Documentation   | -
| License         | MIT


#### What's in this PR?

Declaring `final` all classes that are marked as `@final` for the new major version