### PR TITLE
Allow to disable body limitation size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 - Removed `twig/twig` dependency
 - Removed hard dependency on `php-http/cache-plugin`. If you want to use the
   cache plugin, you need to require it in your project.
+- Allow to set `httpplug.profiling.captured_body_length` configuration to `null`
+  to avoid body limitation size.
 
 ### Fixed
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -147,7 +147,14 @@ class Configuration implements ConfigurationInterface
                                         return null;
                                     }
 
-                                    return (int) $maxLength;
+                                    if (!is_int($maxLength)) {
+                                        $invalidConfiguration = new InvalidConfigurationException('The child node "captured_body_length" at path "httplug.profiling" must be an integer or null.');
+                                        $invalidConfiguration->setPath('httplug.profiling');
+
+                                        throw $invalidConfiguration;
+                                    }
+
+                                    return $maxLength;
                                 })
                             ->end()
                             ->defaultValue(0)

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -142,7 +142,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('formatter')->defaultNull()->end()
                         ->scalarNode('captured_body_length')
                             ->beforeNormalization()
-                                ->always(function($maxLength) {
+                                ->always(function ($maxLength) {
                                     if (null === $maxLength) {
                                         return null;
                                     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -140,9 +140,18 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue($this->debug)
                         ->end()
                         ->scalarNode('formatter')->defaultNull()->end()
-                        ->integerNode('captured_body_length')
+                        ->scalarNode('captured_body_length')
+                            ->beforeNormalization()
+                                ->always(function($maxLength) {
+                                    if (null === $maxLength) {
+                                        return null;
+                                    }
+
+                                    return (int) $maxLength;
+                                })
+                            ->end()
                             ->defaultValue(0)
-                            ->info('Limit long HTTP message bodies to x characters. If set to 0 we do not read the message body. Only available with the default formatter (FullHttpMessageFormatter).')
+                            ->info('Limit long HTTP message bodies to x characters. If set to 0 we do not read the message body. If null the body will not be truncated. Only available with the default formatter (FullHttpMessageFormatter).')
                         ->end()
                     ->end()
                 ->end()

--- a/tests/Resources/Fixtures/config/invalid_captured_body_length.yml
+++ b/tests/Resources/Fixtures/config/invalid_captured_body_length.yml
@@ -1,0 +1,3 @@
+httplug:
+    profiling:
+        captured_body_length: foo

--- a/tests/Resources/Fixtures/config/limitless_captured_body_length.yml
+++ b/tests/Resources/Fixtures/config/limitless_captured_body_length.yml
@@ -1,0 +1,3 @@
+httplug:
+    profiling:
+        captured_body_length: ~

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -403,4 +403,14 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $config['profiling']['captured_body_length'] = null;
         $this->assertProcessedConfigurationEquals($config, [$file]);
     }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage The child node "captured_body_length" at path "httplug.profiling" must be an integer or null.
+     */
+    public function testInvalidCapturedBodyLengthString()
+    {
+        $file = __DIR__.'/../../Resources/Fixtures/config/invalid_captured_body_length.yml';
+        $this->assertProcessedConfigurationEquals([], [$file]);
+    }
 }

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -395,4 +395,12 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $file = __DIR__.'/../../Resources/Fixtures/config/cache_config_with_no_pool.yml';
         $this->assertProcessedConfigurationEquals([], [$file]);
     }
+
+    public function testLimitlessCapturedBodyLength()
+    {
+        $file = __DIR__.'/../../Resources/Fixtures/config/limitless_captured_body_length.yml';
+        $config = $this->emptyConfig;
+        $config['profiling']['captured_body_length'] = null;
+        $this->assertProcessedConfigurationEquals($config, [$file]);
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | https://github.com/php-http/documentation/pull/259
| License         | MIT


#### What's in this PR?

This PR allow to set the `httpplug.profiling.captured_body_length` to `NULL` to avoid body truncate in the Symfony profiler.


#### Why?

I want to view all the body content of a `Request` or `Response`.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)


#### To Do

- [x] If accepted, update documentation


