### PR TITLE
Fix error on undefined variable when a client is named default in config

### DIFF
--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -127,6 +127,7 @@ class HttplugExtension extends Extension
                 $default = $first;
             } else {
                 $default = 'default';
+                $serviceId = 'httplug.client.'.$default;
             }
 
             // Autowiring alias for special clients, if they are enabled on the default client


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

Fix an undefined variable `$serviceId` when the first client is named default in configuration


#### Why?

Fix an undefined variable `$serviceId` when the first client is named default in configuration

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ x] Documentation pull request created (if not simply a bugfix)
