### PR TITLE
Remove enabled key from content type plugin options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+### Fixed
+
+- Fix to pass only allowed options to the `ContentTypePlugin`. 
+
 ## 1.15.1 - 2019-04-12
 
 ### Fixed

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -270,7 +270,9 @@ class HttplugExtension extends Extension
                 break;
 
             case 'content_type':
+                unset($config['enabled']);
                 $definition->replaceArgument(0, $config);
+
                 break;
 
             case 'header_append':

--- a/tests/Resources/Fixtures/config/full.php
+++ b/tests/Resources/Fixtures/config/full.php
@@ -36,6 +36,11 @@ $container->loadFromExtension('httplug', [
                     ],
                 ],
                 [
+                    'content_type' => [
+                        'skip_detection' => true,
+                    ],
+                ],
+                [
                     'header_set' => [
                         'headers' => [
                             'X-FOO' => 'bar',

--- a/tests/Resources/Fixtures/config/full.xml
+++ b/tests/Resources/Fixtures/config/full.xml
@@ -27,6 +27,9 @@
                 <base-uri uri="http://localhost"/>
             </plugin>
             <plugin>
+                <content-type skip-detection="true"/>
+            </plugin>
+            <plugin>
                 <header-set>
                     <header name="X-FOO">bar</header>
                 </header-set>

--- a/tests/Resources/Fixtures/config/full.yml
+++ b/tests/Resources/Fixtures/config/full.yml
@@ -26,6 +26,9 @@ httplug:
                     base_uri:
                         uri: http://localhost
                 -
+                    content_type:
+                        skip_detection: true
+                -
                     header_set:
                         headers:
                             X-FOO: bar

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -152,6 +152,12 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                             ],
                         ],
                         [
+                            'content_type' => [
+                                'enabled' => true,
+                                'skip_detection' => true,
+                            ],
+                        ],
+                        [
                             'header_set' => [
                                 'enabled' => true,
                                 'headers' => [

--- a/tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -254,6 +254,32 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         $this->assertSame('header_cache_key_generator', (string) $config['cache_key_generator']);
     }
 
+    public function testContentTypePluginAllowedOptions()
+    {
+        $this->load([
+            'clients' => [
+                'acme' => [
+                    'plugins' => [
+                        [
+                            'content_type' => [
+                                'skip_detection' => true,
+                                'size_limit' => 200000,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $cachePlugin = $this->container->findDefinition('httplug.client.acme.plugin.content_type');
+
+        $config = $cachePlugin->getArgument(0);
+        $this->assertEquals([
+            'skip_detection' => true,
+            'size_limit' => 200000,
+        ], $config);
+    }
+
     public function testUsingServiceKeyForClients()
     {
         $this->load([


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Removes the `enabled` key from the `$config` array passed to the `ContentTypePlugin` constructor options.


#### Why?

The `content_type` plugin configuration can be enabled and thus has an `enabled` option in it's configuration. If this is passed without removing the `enabled` key, the options resolver of the `ContentTypePlugin` constructor options throws an exception:

```
The option "enabled" does not exist. Defined options are: "size_limit", "skip_detection".
```

#### Checklist

- [x] Updated CHANGELOG.md to describe bugfix
