### PR TITLE
Fix: Drop support for unsupported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,6 @@ matrix:
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak" SYMFONY_PHPUNIT_VERSION="5.7"
 
           # Test the latest stable release
-        - php: 5.5
-          env: SYMFONY_PHPUNIT_VERSION="5.7"
-        - php: 5.6
-          env: SYMFONY_PHPUNIT_VERSION="5.7"
-        - php: 7.0
         - php: 7.1
         - php: 7.2
         - php: 7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 - Integration for VCR Plugin
 
+### Changed
+
+- **[BC] Dropped support for PHP 5.5, 5.6, and 7.0**
+
 ## 1.15.2 - 2019-04-18
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^7.1",
         "php-http/client-common": "^1.9 || ^2.0",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | #333 
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

This PR

* [x] drops support for unsupported PHP versions following the merge of #333

#### Why?

The build is currently broken as [`php-http/vcr-plugin:^1.0@dev`]() requires PHP 7.1.

#### Example Usage

n/a

#### Checklist

- [x] Updated `CHANGELOG.md` to describe BC breaks


#### To Do

n/a