### PR TITLE
Add compatibility with curl-client v2 (now relying on PSR17 factories)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ matrix:
 
           # Test with httplug 1.x clients
         - php: 7.2
-          env: DEPENDENCIES="php-http/buzz-adapter:^1.0 php-http/curl-client:^1.0 php-http/guzzle6-adapter:^1.1.1 php-http/react-adapter:^0.2.1 php-http/socket-client:^1.0"
+          env: DEPENDENCIES="php-http/buzz-adapter:^1.0 php-http/guzzle6-adapter:^1.1.1 php-http/react-adapter:^0.2.1 php-http/socket-client:^1.0"
 
           # Test with httplug 2.x clients
         - php: 7.2
-          env: DEPENDENCIES="php-http/guzzle6-adapter:^2.0.1"
+          env: DEPENDENCIES="php-http/guzzle6-adapter:^2.0.1 php-http/curl-client:^2.0.0"
 
           # Latest commit to master
         - php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
         - php: 7.1
         - php: 7.2
         - php: 7.3
-          env: COVERAGE=true TEST_COMMAND="composer test-ci"
+          env: COVERAGE=true TEST_COMMAND="composer test-ci" DEPENDENCIES="php-http/vcr-plugin:^1.0@dev"
 
           # Test LTS versions
         - php: 7.3
@@ -42,11 +42,11 @@ matrix:
 
           # Test with httplug 2.x clients
         - php: 7.2
-          env: DEPENDENCIES="php-http/guzzle6-adapter:^2.0.1 php-http/curl-client:^2.0.0"
+          env: DEPENDENCIES="php-http/guzzle6-adapter:^2.0.1 php-http/curl-client:^2.0.0 php-http/vcr-plugin:^1.0@dev"
 
           # Latest commit to master
         - php: 7.3
-          env: STABILITY="dev"
+          env: STABILITY="dev" DEPENDENCIES="php-http/vcr-plugin:^1.0@dev"
 
     allow_failures:
           # dev stability is allowed to fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,18 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 ### Added
 
 - Integration for VCR Plugin
+- curl-client v1.* is marked in conflict with the current bundle version.
+
+### Fixed
+
+- Fix compatibility with curl-client v2.*, the `CurlFactory` now build the
+  client using PSR17 factories.
 
 ## 1.15.2 - 2019-04-18
 
 ### Fixed
 
-- Fix to pass only allowed options to the `ContentTypePlugin`. 
+- Fix to pass only allowed options to the `ContentTypePlugin`.
 
 ## 1.15.1 - 2019-04-12
 
@@ -34,7 +40,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
   (Only available with Httplug 2)
 - Configuration for the content_type plugin
 - Support for namespaced Twig classes.
-- Configuration option default_client_autowiring that you can set to false 
+- Configuration option default_client_autowiring that you can set to false
   to prevent autowiring the HttpClient and HttpAsyncClient
 
 ### Changed
@@ -58,7 +64,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ### Added
 
-- Support for any PSR-18 client. 
+- Support for any PSR-18 client.
 
 ### Changed
 
@@ -100,14 +106,14 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 ## 1.10.0 - 2018-03-27
 
 ### Added
- 
+
 - Allow to configure the `AddPathPlugin` per client, under the `add_path` configuration key.
-- Allow to configure clients with a `service` instead of a factory. 
+- Allow to configure clients with a `service` instead of a factory.
 
 ## 1.9.0 - 2018-03-06
 
 ### Added
- 
+
 - Allow to configure the `BaseUriPlugin` per client, under the `base_uri` configuration key.
 
 ## 1.8.1 - 2017-12-06
@@ -120,7 +126,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ### Added
 
-- Symfony 4 support. 
+- Symfony 4 support.
 - Support autowiring of `Http\Client\Common\PluginClientFactory`.
 - Any third party library using `Http\Client\Common\PluginClientFactory` to create `Http\Client\Common\PluginClient`
 instances now gets zero config profiling.
@@ -170,8 +176,8 @@ services aliases for autowiring in Symfony 3.3.
 
 ### Changed
 
-- We do collect profiler data after the request is processed by a plugin. With this change we 
-will for example see the changes of `HeaderAppendPlugin` at that plugin instead of the next one. 
+- We do collect profiler data after the request is processed by a plugin. With this change we
+will for example see the changes of `HeaderAppendPlugin` at that plugin instead of the next one.
 
 ## 1.5.0 - 2017-05-05
 

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         "php-http/guzzle6-adapter": "^1.1.1 || ^2.0.1",
         "php-http/mock-client": "^1.2",
         "php-http/promise": "^1.0",
-        "php-http/vcr-plugin": "^1.0@dev",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
         "symfony/cache": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "symfony/options-resolver": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1"
     },
     "conflict": {
-        "php-http/guzzle6-adapter": "<1.1"
+        "php-http/guzzle6-adapter": "<1.1",
+        "php-http/curl-client": "<2.0"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.0",

--- a/src/ClientFactory/CurlFactory.php
+++ b/src/ClientFactory/CurlFactory.php
@@ -3,8 +3,8 @@
 namespace Http\HttplugBundle\ClientFactory;
 
 use Http\Client\Curl\Client;
-use Http\Message\MessageFactory;
-use Http\Message\StreamFactory;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -12,22 +12,22 @@ use Http\Message\StreamFactory;
 class CurlFactory implements ClientFactory
 {
     /**
-     * @var MessageFactory
+     * @var ResponseFactoryInterface
      */
-    private $messageFactory;
+    private $responseFactory;
 
     /**
-     * @var StreamFactory
+     * @var StreamFactoryInterface
      */
     private $streamFactory;
 
     /**
-     * @param MessageFactory $messageFactory
-     * @param StreamFactory  $streamFactory
+     * @param ResponseFactoryInterface $responseFactory
+     * @param StreamFactoryInterface   $streamFactory
      */
-    public function __construct(MessageFactory $messageFactory, StreamFactory $streamFactory)
+    public function __construct(ResponseFactoryInterface $responseFactory, StreamFactoryInterface $streamFactory)
     {
-        $this->messageFactory = $messageFactory;
+        $this->responseFactory = $responseFactory;
         $this->streamFactory = $streamFactory;
     }
 
@@ -53,6 +53,6 @@ class CurlFactory implements ClientFactory
             }
         }
 
-        return new Client($this->messageFactory, $this->streamFactory, $config);
+        return new Client($this->responseFactory, $this->streamFactory, $config);
     }
 }

--- a/tests/Unit/ClientFactory/CurlFactoryTest.php
+++ b/tests/Unit/ClientFactory/CurlFactoryTest.php
@@ -4,9 +4,9 @@ namespace Http\HttplugBundle\Tests\Unit\ClientFactory;
 
 use Http\HttplugBundle\ClientFactory\CurlFactory;
 use Http\Client\Curl\Client;
-use Http\Message\MessageFactory;
-use Http\Message\StreamFactory;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -20,8 +20,8 @@ class CurlFactoryTest extends TestCase
         }
 
         $factory = new CurlFactory(
-            $this->getMockBuilder(MessageFactory::class)->getMock(),
-            $this->getMockBuilder(StreamFactory::class)->getMock()
+            $this->getMockBuilder(ResponseFactoryInterface::class)->getMock(),
+            $this->getMockBuilder(StreamFactoryInterface::class)->getMock()
         );
         $client = $factory->createClient();
 

--- a/tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -457,6 +457,10 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
      */
     public function testVcrPluginConfiguration(array $config, array $services, array $arguments = [])
     {
+        if (!class_exists(\Http\Client\Plugin\Vcr\Recorder\InMemoryRecorder::class)) {
+            $this->markTestSkipped('VCR plugin is not installed.');
+        }
+
         $prefix = 'httplug.client.acme.vcr';
         $this->load(['clients' => ['acme' => ['plugins' => [['vcr' => $config]]]]]);
         $this->assertContainerBuilderHasService('httplug.plugin.vcr.recorder.in_memory', InMemoryRecorder::class);
@@ -477,6 +481,10 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
      */
     public function testIsNotLoadedUnlessNeeded()
     {
+        if (!class_exists(\Http\Client\Plugin\Vcr\Recorder\InMemoryRecorder::class)) {
+            $this->markTestSkipped('VCR plugin is not installed.');
+        }
+
         $this->load(['clients' => ['acme' => ['plugins' => []]]]);
         $this->assertContainerBuilderNotHasService('httplug.plugin.vcr.recorder.in_memory');
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | fix #338 
| License         | MIT


#### What's in this PR?

This PR contains the compatibility with php-http/curl-client v2.

#### Why?

Installing the bundle with the curl-client will trigger that error now :

```
Argument 1 passed to Http\Client\Curl\Client::__construct() must be an instance of Psr\Http\Message\ResponseFactoryInterface or null, instance of Nyholm\Psr7\Factory\HttplugFactory given, called in /vagrant/vendor/php-http/httplug-bundle/src/ClientFactory/CurlFactory.php on line 5
```

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

#### To Do

- [x] Handle compatibility with curl-client v1 in parallel of v2
