### PR TITLE
Enhancement: Use short array syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Enable the bundle in your kernel:
 
 public function registerBundles()
 {
-    $bundles = array(
+    $bundles = [
         // ...
         new Http\HttplugBundle\HttplugBundle(),
-    );
+    ];
 }
 ```
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT

#### What's in this PR?

This PR

* [x] uses short array syntax in `README.md`

#### Why?

Since this package requires at least PHP 7.1, I think it's safe to use short array syntax in code examples.