### PR TITLE
drop support for unmaintained Symfony versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 ### Changed
 
 - Dropped support for PHP < 7.1
-- Dropped support for Symfony 2 
+- Dropped support for Symfony versions that do not receive bugfixes
 
 ### Added
 

--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,11 @@
         "php-http/message-factory": "^1.0.2",
         "php-http/stopwatch-plugin": "^1.2",
         "psr/http-message": "^1.0",
-        "symfony/config": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "symfony/dependency-injection": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "symfony/event-dispatcher": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "symfony/http-kernel": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "symfony/options-resolver": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1"
+        "symfony/config": "^3.4.20 || ^4.2.1",
+        "symfony/dependency-injection": "^3.4.20 || ^4.2.1",
+        "symfony/event-dispatcher": "^3.4.20 || ^4.2.1",
+        "symfony/http-kernel": "^3.4.20 || ^4.2.1",
+        "symfony/options-resolver": "^3.4.20 || ^4.2.1"
     },
     "conflict": {
         "php-http/guzzle6-adapter": "<1.1"
@@ -54,15 +54,15 @@
         "php-http/promise": "^1.0",
         "php-http/vcr-plugin": "^1.0@dev",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
-        "symfony/browser-kit": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "symfony/cache": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "symfony/dom-crawler": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "symfony/framework-bundle": "^3.4.0 || ^4.0",
-        "symfony/http-foundation": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
+        "symfony/browser-kit": "^3.4.20 || ^4.2.1",
+        "symfony/cache": "^3.4.20 || ^4.2.1",
+        "symfony/dom-crawler": "^3.4.20 || ^4.2.1",
+        "symfony/framework-bundle": "^3.4.0 || ^4.2",
+        "symfony/http-foundation": "^3.4.20 || ^4.2.1",
         "symfony/phpunit-bridge": "^3.4 || ^4.2",
-        "symfony/stopwatch": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "symfony/twig-bundle": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
-        "symfony/web-profiler-bundle": "^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1",
+        "symfony/stopwatch": "^3.4.20 || ^4.2.1",
+        "symfony/twig-bundle": "^3.4.20 || ^4.2.1",
+        "symfony/web-profiler-bundle": "^3.4.20 || ^4.2.1",
         "twig/twig": "^1.36 || ^2.6"
     },
     "suggest": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | continues #340
| Documentation   | 
| License         | MIT


#### What's in this PR?

Also drops support for Symfony 4.0 and 4.1 which do not receive bugfixes anymore.


#### Why?

see #340

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix