### PR TITLE
Fix: Use assertSame()

### DIFF
--- a/tests/Unit/ClientFactory/MockFactoryTest.php
+++ b/tests/Unit/ClientFactory/MockFactoryTest.php
@@ -28,6 +28,6 @@ class MockFactoryTest extends TestCase
 
         $factory->setClient($client);
 
-        $this->assertEquals($client, $factory->createClient());
+        $this->assertSame($client, $factory->createClient());
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT

#### What's in this PR?

This PR

* [x] uses `assertSame()` to harden a test

#### Why?

When applying the following patch 

```diff
diff --git a/src/ClientFactory/MockFactory.php b/src/ClientFactory/MockFactory.php
index c56d38c..e57d373 100644
--- a/src/ClientFactory/MockFactory.php
+++ b/src/ClientFactory/MockFactory.php
@@ -10,11 +10,6 @@ use Http\Mock\Client;
  */
 final class MockFactory implements ClientFactory
 {
-    /**
-     * @var HttpClient
-     */
-    private $client;
-
     /**
      * Set the client instance that this factory should return.
      *
@@ -22,7 +17,6 @@ final class MockFactory implements ClientFactory
      */
     public function setClient(HttpClient $client)
     {
-        $this->client = $client;
     }

     /**
@@ -34,10 +28,6 @@ final class MockFactory implements ClientFactory
             throw new \LogicException('To use the mock adapter you need to install the "php-http/mock-client" package.');
         }

-        if (!$this->client) {
-            $this->client = new Client();
-        }
-
-        return $this->client;
+        return new Client();
     }
 }
```

to current `master`, the tests still pass.