### PR TITLE
Enhancement: Tag clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## Unreleased
+
+### Added
+
+- Configured clients are now tagged with `'httplug.client'`
+
 ## 1.16.0 - 2019-06-05
 
 ### Changed

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -37,6 +37,8 @@ use Twig\Environment as TwigEnvironment;
  */
 class HttplugExtension extends Extension
 {
+    public const HTTPLUG_CLIENT_TAG = 'httplug.client';
+
     /**
      * Used to check is the VCR plugin is installed.
      *
@@ -419,6 +421,7 @@ class HttplugExtension extends Extension
             ->addArgument([
                 'client_name' => $clientName,
             ])
+            ->addTag(self::HTTPLUG_CLIENT_TAG)
         ;
 
         if (is_bool($arguments['public'])) {

--- a/tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -31,6 +31,11 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         ];
     }
 
+    public function testConstants(): void
+    {
+        self::assertSame('httplug.client', HttplugExtension::HTTPLUG_CLIENT_TAG);
+    }
+
     public function testConfigLoadDefault(): void
     {
         $this->load();
@@ -450,6 +455,25 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
             // Symfony made services private by default starting from 3.4
             $this->assertFalse($this->container->getDefinition('httplug.client.acme.batch_client')->isPrivate());
         }
+    }
+
+    public function testClientIsTaggedWithHttplugClientTag(): void
+    {
+        $this->load([
+            'clients' => [
+                'acme' => null,
+            ],
+        ]);
+
+        $serviceId = 'httplug.client.acme';
+
+        $this->assertContainerBuilderHasService($serviceId);
+
+        $this->assertTrue($this->container->getDefinition($serviceId)->hasTag(HttplugExtension::HTTPLUG_CLIENT_TAG), sprintf(
+            'Failed asserting that client with service identifier "%s" has been tagged with "%s".',
+            $serviceId,
+            HttplugExtension::HTTPLUG_CLIENT_TAG
+        ));
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related to #346
| Documentation   | https://github.com/php-http/documentation/pull/268
| License         | MIT

#### What's in this PR?

This PR 

* [x] adds the tag `'httplug.client'` to clients created by the `HttplugExtension`

#### Why?

This would allow fetching services by tag and replacing them, for example, with a concrete `Mock\Client`, without having to know the exact service identifier. 

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)
