### PR TITLE
Enhancement: Configure visibility_required fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,7 +8,7 @@ $finder = PhpCsFixer\Finder::create()
 
 return PhpCsFixer\Config::create()
     ->setRules([
-         '@Symfony' => true,
-         'array_syntax' => ['syntax' => 'short'],
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
     ])
     ->setFinder($finder);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -10,5 +10,12 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'visibility_required' => [
+            'elements' => [
+                'const',
+                'method',
+                'property',
+            ],
+        ],
     ])
     ->setFinder($finder);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT

#### What's in this PR?

This PR

* [x] fixes the indentation in `php_cs.dist`
* [x] configures the `visibility_required` fixer to also require visibility on constants

Somewhat related to #348.

#### Why?

The minimum required PHP version is PHP 7.1, so we might just as well make use of the features.