### PR TITLE
Enhancement: Apply void_return fixer to tests

### DIFF
--- a/tests/Functional/DiscoveredClientsTest.php
+++ b/tests/Functional/DiscoveredClientsTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\Event;
 
 class DiscoveredClientsTest extends WebTestCase
 {
-    public function testDiscoveredClient()
+    public function testDiscoveredClient(): void
     {
         $container = $this->getContainer(false);
 
@@ -26,7 +26,7 @@ class DiscoveredClientsTest extends WebTestCase
         $this->assertInstanceOf(HttpClient::class, $service);
     }
 
-    public function testDiscoveredAsyncClient()
+    public function testDiscoveredAsyncClient(): void
     {
         $container = $this->getContainer(false);
 
@@ -37,7 +37,7 @@ class DiscoveredClientsTest extends WebTestCase
         $this->assertInstanceOf(HttpAsyncClient::class, $service);
     }
 
-    public function testDiscoveredClientWithProfilingEnabled()
+    public function testDiscoveredClientWithProfilingEnabled(): void
     {
         $container = $this->getContainer(true);
 
@@ -49,7 +49,7 @@ class DiscoveredClientsTest extends WebTestCase
         $this->assertInstanceOf(HttpClient::class, NSA::getProperty($service, 'client'));
     }
 
-    public function testDiscoveredAsyncClientWithProfilingEnabled()
+    public function testDiscoveredAsyncClientWithProfilingEnabled(): void
     {
         $container = $this->getContainer(true);
 
@@ -64,7 +64,7 @@ class DiscoveredClientsTest extends WebTestCase
     /**
      * Test with httplug.discovery.client: "auto".
      */
-    public function testDiscovery()
+    public function testDiscovery(): void
     {
         $container = $this->getContainer(true);
 
@@ -86,7 +86,7 @@ class DiscoveredClientsTest extends WebTestCase
     /**
      * Test with httplug.discovery.client: null.
      */
-    public function testDisabledDiscovery()
+    public function testDisabledDiscovery(): void
     {
         $container = $this->getContainer(true, 'discovery_disabled');
 
@@ -98,7 +98,7 @@ class DiscoveredClientsTest extends WebTestCase
     /**
      * Test with httplug.discovery.client: "httplug.client.acme".
      */
-    public function testForcedDiscovery()
+    public function testForcedDiscovery(): void
     {
         $container = $this->getContainer(true, 'discovery_forced');
 
@@ -119,7 +119,7 @@ class DiscoveredClientsTest extends WebTestCase
         return static::$kernel->getContainer();
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Functional/DiscoveryTest.php
+++ b/tests/Functional/DiscoveryTest.php
@@ -20,7 +20,7 @@ use Http\Adapter\Guzzle6\Client;
  */
 final class DiscoveryTest extends AbstractExtensionTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -37,7 +37,7 @@ final class DiscoveryTest extends AbstractExtensionTestCase
         ];
     }
 
-    public function testDiscoveryFallbacks()
+    public function testDiscoveryFallbacks(): void
     {
         $this->load();
 
@@ -48,7 +48,7 @@ final class DiscoveryTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService('httplug.async_client.default', HttpAsyncClient::class);
     }
 
-    public function testDiscoveryPartialFallbacks()
+    public function testDiscoveryPartialFallbacks(): void
     {
         $this->load();
         $this->setDefinition('httplug.client.default', new Definition(Client::class));
@@ -60,7 +60,7 @@ final class DiscoveryTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService('httplug.async_client.default', HttpAsyncClient::class);
     }
 
-    public function testNoDiscoveryFallbacks()
+    public function testNoDiscoveryFallbacks(): void
     {
         $this->setDefinition('httplug.client.default', new Definition(HttpClient::class));
         $this->setDefinition('httplug.message_factory.default', new Definition(MessageFactory::class));
@@ -75,7 +75,7 @@ final class DiscoveryTest extends AbstractExtensionTestCase
         $this->assertEquals([HttpClientDiscovery::class, 'find'], $clientDefinition->getFactory());
     }
 
-    public function testEnableAutowiring()
+    public function testEnableAutowiring(): void
     {
         $this->load([
             'default_client_autowiring' => true,
@@ -87,7 +87,7 @@ final class DiscoveryTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasAlias(HttpAsyncClient::class);
     }
 
-    public function testDisableAutowiring()
+    public function testDisableAutowiring(): void
     {
         if (PHP_VERSION_ID <= 70000) {
             $this->markTestSkipped();

--- a/tests/Functional/Issue206.php
+++ b/tests/Functional/Issue206.php
@@ -13,7 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class Issue206 extends WebTestCase
 {
-    public function testCustomClientDoesNotCauseException()
+    public function testCustomClientDoesNotCauseException(): void
     {
         static::bootKernel();
         $container = static::$kernel->getContainer();

--- a/tests/Functional/ProfilerTest.php
+++ b/tests/Functional/ProfilerTest.php
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class ProfilerTest extends WebTestCase
 {
-    public function testShowProfiler()
+    public function testShowProfiler(): void
     {
         $client = static::createClient();
 

--- a/tests/Functional/ProfilingTest.php
+++ b/tests/Functional/ProfilingTest.php
@@ -37,14 +37,14 @@ class ProfilingTest extends TestCase
      */
     private $stopwatch;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->collector = new Collector([]);
         $this->formatter = new Formatter(new FullHttpMessageFormatter(), new CurlCommandFormatter());
         $this->stopwatch = new Stopwatch();
     }
 
-    public function testProfilingWithCachePlugin()
+    public function testProfilingWithCachePlugin(): void
     {
         $client = $this->createClient([
             new Plugin\CachePlugin(new ArrayAdapter(), StreamFactoryDiscovery::find(), [
@@ -64,7 +64,7 @@ class ProfilingTest extends TestCase
         $this->assertEquals('example.com', $stack->getRequestHost());
     }
 
-    public function testProfilingWhenPluginThrowException()
+    public function testProfilingWhenPluginThrowException(): void
     {
         $client = $this->createClient([
             new ExceptionThrowerPlugin(),
@@ -83,7 +83,7 @@ class ProfilingTest extends TestCase
         }
     }
 
-    public function testProfiling()
+    public function testProfiling(): void
     {
         $client = $this->createClient([
             new Plugin\AddHostPlugin(UriFactoryDiscovery::find()->createUri('https://example.com')),
@@ -122,7 +122,7 @@ class ExceptionThrowerPlugin implements Plugin
 {
     use Plugin\VersionBridgePlugin;
 
-    protected function doHandleRequest(RequestInterface $request, callable $next, callable $first)
+    protected function doHandleRequest(RequestInterface $request, callable $next, callable $first): void
     {
         throw new \Exception();
     }

--- a/tests/Functional/ServiceInstantiationTest.php
+++ b/tests/Functional/ServiceInstantiationTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Profiler\Profiler;
 
 class ServiceInstantiationTest extends WebTestCase
 {
-    public function testHttpClient()
+    public function testHttpClient(): void
     {
         static::bootKernel();
         $container = static::$kernel->getContainer();
@@ -33,7 +33,7 @@ class ServiceInstantiationTest extends WebTestCase
         $this->assertInstanceOf(HttpClient::class, $client);
     }
 
-    public function testHttpClientNoDebug()
+    public function testHttpClientNoDebug(): void
     {
         static::bootKernel(['debug' => false]);
         $container = static::$kernel->getContainer();
@@ -42,7 +42,7 @@ class ServiceInstantiationTest extends WebTestCase
         $this->assertInstanceOf(HttpClient::class, $client);
     }
 
-    public function testDebugToolbar()
+    public function testDebugToolbar(): void
     {
         static::bootKernel(['debug' => true]);
         $container = static::$kernel->getContainer();
@@ -54,7 +54,7 @@ class ServiceInstantiationTest extends WebTestCase
         $this->assertInstanceOf(Collector::class, $collector);
     }
 
-    public function testProfilingShouldNotChangeServiceReference()
+    public function testProfilingShouldNotChangeServiceReference(): void
     {
         static::bootKernel(['debug' => true]);
         $container = static::$kernel->getContainer();
@@ -62,7 +62,7 @@ class ServiceInstantiationTest extends WebTestCase
         $this->assertInstanceof(RedirectPlugin::class, $container->get('app.http.plugin.custom'));
     }
 
-    public function testProfilingDecoration()
+    public function testProfilingDecoration(): void
     {
         static::bootKernel(['debug' => true]);
         $container = static::$kernel->getContainer();
@@ -81,7 +81,7 @@ class ServiceInstantiationTest extends WebTestCase
         $this->assertInstanceOf(ProfilePlugin::class, $plugins[4]);
     }
 
-    public function testProfilingPsr18Decoration()
+    public function testProfilingPsr18Decoration(): void
     {
         if (!interface_exists(ClientInterface::class)) {
             $this->markTestSkipped('PSR-18 is not installed');

--- a/tests/Resources/app/AppKernel.php
+++ b/tests/Resources/app/AppKernel.php
@@ -38,7 +38,7 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/config/config_'.$this->getEnvironment().'.yml');
         if ($this->isDebug()) {
@@ -49,7 +49,7 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
     {
         $routes->import('@WebProfilerBundle/Resources/config/routing/wdt.xml', '/_wdt');
         $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml', '/_profiler');
@@ -94,7 +94,7 @@ class AppKernel extends Kernel
         return new Response();
     }
 
-    protected function build(ContainerBuilder $container)
+    protected function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new PublicServicesForFunctionalTestsPass());
     }
@@ -102,7 +102,7 @@ class AppKernel extends Kernel
 
 class PublicServicesForFunctionalTestsPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $services = [
             'httplug.strategy',

--- a/tests/Unit/ClientFactory/BuzzFactoryTest.php
+++ b/tests/Unit/ClientFactory/BuzzFactoryTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class BuzzFactoryTest extends TestCase
 {
-    public function testCreateClient()
+    public function testCreateClient(): void
     {
         if (!class_exists(Client::class)) {
             $this->markTestSkipped('Buzz adapter is not installed');

--- a/tests/Unit/ClientFactory/CurlFactoryTest.php
+++ b/tests/Unit/ClientFactory/CurlFactoryTest.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\StreamFactoryInterface;
  */
 class CurlFactoryTest extends TestCase
 {
-    public function testCreateClient()
+    public function testCreateClient(): void
     {
         if (!class_exists(Client::class)) {
             $this->markTestSkipped('Curl client is not installed');

--- a/tests/Unit/ClientFactory/Guzzle6FactoryTest.php
+++ b/tests/Unit/ClientFactory/Guzzle6FactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
  */
 class Guzzle6FactoryTest extends TestCase
 {
-    public function testCreateClient()
+    public function testCreateClient(): void
     {
         if (!class_exists(Client::class)) {
             $this->markTestSkipped('Guzzle6 adapter is not installed');

--- a/tests/Unit/ClientFactory/MockFactoryTest.php
+++ b/tests/Unit/ClientFactory/MockFactoryTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MockFactoryTest extends TestCase
 {
-    public function testCreateClient()
+    public function testCreateClient(): void
     {
         $factory = new MockFactory();
         $client = $factory->createClient();

--- a/tests/Unit/ClientFactory/ReactFactoryTest.php
+++ b/tests/Unit/ClientFactory/ReactFactoryTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ReactFactoryTest extends TestCase
 {
-    public function testCreateClient()
+    public function testCreateClient(): void
     {
         if (!class_exists(Client::class)) {
             $this->markTestSkipped('React adapter is not installed');

--- a/tests/Unit/ClientFactory/SocketFactoryTest.php
+++ b/tests/Unit/ClientFactory/SocketFactoryTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class SocketFactoryTest extends TestCase
 {
-    public function testCreateClient()
+    public function testCreateClient(): void
     {
         if (!class_exists(Client::class)) {
             $this->markTestSkipped('Socket client is not installed');

--- a/tests/Unit/Collector/CollectorTest.php
+++ b/tests/Unit/Collector/CollectorTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class CollectorTest extends TestCase
 {
-    public function testCollectClientNames()
+    public function testCollectClientNames(): void
     {
         $collector = new Collector();
 
@@ -19,7 +19,7 @@ class CollectorTest extends TestCase
         $this->assertEquals(['default', 'acme'], $collector->getClients());
     }
 
-    public function testActivateStack()
+    public function testActivateStack(): void
     {
         $parent = new Stack('acme', 'GET / HTTP/1.1');
         $stack = new Stack('acme', 'GET / HTTP/1.1');
@@ -33,7 +33,7 @@ class CollectorTest extends TestCase
         $this->assertEquals($stack, $collector->getActiveStack());
     }
 
-    public function testDeactivateStack()
+    public function testDeactivateStack(): void
     {
         $stack = new Stack('acme', 'GET / HTTP/1.1');
         $collector = new Collector();
@@ -45,7 +45,7 @@ class CollectorTest extends TestCase
         $this->assertNull($collector->getActiveStack());
     }
 
-    public function testDeactivateStackSetParentAsActiveStack()
+    public function testDeactivateStackSetParentAsActiveStack(): void
     {
         $parent = new Stack('acme', 'GET / HTTP/1.1');
         $stack = new Stack('acme', 'GET / HTTP/1.1');
@@ -59,7 +59,7 @@ class CollectorTest extends TestCase
         $this->assertEquals($parent, $collector->getActiveStack());
     }
 
-    public function testAddStack()
+    public function testAddStack(): void
     {
         $stack = new Stack('acme', 'GET / HTTP/1.1');
         $collector = new Collector();
@@ -70,7 +70,7 @@ class CollectorTest extends TestCase
         $this->assertEquals([$stack], $collector->getClientRootStacks('acme'));
     }
 
-    public function testResetAction()
+    public function testResetAction(): void
     {
         $stack = new Stack('acme', 'GET / HTTP/1.1');
 

--- a/tests/Unit/Collector/FormatterTest.php
+++ b/tests/Unit/Collector/FormatterTest.php
@@ -29,7 +29,7 @@ class FormatterTest extends TestCase
      */
     private $subject;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->formatter = $this->getMockBuilder(MessageFormatter::class)->getMock();
         $this->curlFormatter = $this->getMockBuilder(CurlCommandFormatter::class)->getMock();
@@ -37,7 +37,7 @@ class FormatterTest extends TestCase
         $this->subject = new Formatter($this->formatter, $this->curlFormatter);
     }
 
-    public function testFormatRequest()
+    public function testFormatRequest(): void
     {
         $request = new Request('GET', '/');
 
@@ -50,7 +50,7 @@ class FormatterTest extends TestCase
         $this->subject->formatRequest($request);
     }
 
-    public function testFormatResponse()
+    public function testFormatResponse(): void
     {
         $response = new Response();
 
@@ -63,7 +63,7 @@ class FormatterTest extends TestCase
         $this->subject->formatResponse($response);
     }
 
-    public function testFormatHttpException()
+    public function testFormatHttpException(): void
     {
         $request = new Request('GET', '/');
         $response = new Response();
@@ -79,20 +79,20 @@ class FormatterTest extends TestCase
         $this->assertEquals('FormattedException', $this->subject->formatException($exception));
     }
 
-    public function testFormatTransferException()
+    public function testFormatTransferException(): void
     {
         $exception = new TransferException('ExceptionMessage');
 
         $this->assertEquals('Transfer error: ExceptionMessage', $this->subject->formatException($exception));
     }
 
-    public function testFormatException()
+    public function testFormatException(): void
     {
         $exception = new \RuntimeException('Unexpected error');
         $this->assertEquals('Unexpected exception of type "RuntimeException": Unexpected error', $this->subject->formatException($exception));
     }
 
-    public function testFormatAsCurlCommand()
+    public function testFormatAsCurlCommand(): void
     {
         $request = new Request('GET', '/');
 

--- a/tests/Unit/Collector/PluginClientFactoryListenerTest.php
+++ b/tests/Unit/Collector/PluginClientFactoryListenerTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
 final class PluginClientFactoryListenerTest extends TestCase
 {
-    public function testRegisterPluginClientFactory()
+    public function testRegisterPluginClientFactory(): void
     {
         $collector = $this->getMockBuilder(Collector::class)->getMock();
         $formatter = $this->getMockBuilder(Formatter::class)->disableOriginalConstructor()->getMock();

--- a/tests/Unit/Collector/ProfileClientFactoryTest.php
+++ b/tests/Unit/Collector/ProfileClientFactoryTest.php
@@ -33,7 +33,7 @@ class ProfileClientFactoryTest extends TestCase
      */
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->collector = $this->getMockBuilder(Collector::class)->disableOriginalConstructor()->getMock();
         $this->formatter = $this->getMockBuilder(Formatter::class)->disableOriginalConstructor()->getMock();
@@ -41,7 +41,7 @@ class ProfileClientFactoryTest extends TestCase
         $this->client = $this->getMockBuilder(HttpClient::class)->getMock();
     }
 
-    public function testCreateClientFromClientFactory()
+    public function testCreateClientFromClientFactory(): void
     {
         $factory = $this->getMockBuilder(ClientFactory::class)->getMock();
         $factory->method('createClient')->willReturn($this->client);
@@ -51,7 +51,7 @@ class ProfileClientFactoryTest extends TestCase
         $this->assertInstanceOf(ProfileClient::class, $subject->createClient());
     }
 
-    public function testCreateClientFromCallable()
+    public function testCreateClientFromCallable(): void
     {
         $factory = function ($config) {
             return $this->client;

--- a/tests/Unit/Collector/ProfileClientTest.php
+++ b/tests/Unit/Collector/ProfileClientTest.php
@@ -88,7 +88,7 @@ class ProfileClientTest extends TestCase
      */
     private $uri;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->collector = $this->getMockBuilder(Collector::class)->disableOriginalConstructor()->getMock();
         $this->activeStack = new Stack('default', 'FormattedRequest');
@@ -127,7 +127,7 @@ class ProfileClientTest extends TestCase
         ;
     }
 
-    public function testSendRequest()
+    public function testSendRequest(): void
     {
         $this->client
             ->expects($this->once())
@@ -145,7 +145,7 @@ class ProfileClientTest extends TestCase
         $this->assertEquals('https', $this->activeStack->getRequestScheme());
     }
 
-    public function testSendAsyncRequest()
+    public function testSendAsyncRequest(): void
     {
         $this->client
             ->expects($this->once())
@@ -168,7 +168,7 @@ class ProfileClientTest extends TestCase
         $this->assertEquals('https', $this->activeStack->getRequestScheme());
     }
 
-    public function testOnFulfilled()
+    public function testOnFulfilled(): void
     {
         $this->collector
             ->expects($this->once())
@@ -193,7 +193,7 @@ class ProfileClientTest extends TestCase
         $this->assertEquals('FormattedResponse', $this->activeStack->getClientResponse());
     }
 
-    public function testOnRejected()
+    public function testOnRejected(): void
     {
         $this->collector
             ->expects($this->once())

--- a/tests/Unit/Collector/ProfilePluginTest.php
+++ b/tests/Unit/Collector/ProfilePluginTest.php
@@ -69,7 +69,7 @@ class ProfilePluginTest extends TestCase
      */
     private $subject;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->plugin = $this->getMockBuilder(Plugin::class)->getMock();
         $this->collector = $this->getMockBuilder(Collector::class)->disableOriginalConstructor()->getMock();
@@ -119,7 +119,7 @@ class ProfilePluginTest extends TestCase
         );
     }
 
-    public function testCallDecoratedPlugin()
+    public function testCallDecoratedPlugin(): void
     {
         $this->plugin
             ->expects($this->once())
@@ -129,15 +129,15 @@ class ProfilePluginTest extends TestCase
 
         $this->subject->handleRequest($this->request, function () {
             return $this->fulfilledPromise;
-        }, function () {
+        }, function (): void {
         });
     }
 
-    public function testProfileIsInitialized()
+    public function testProfileIsInitialized(): void
     {
         $this->subject->handleRequest($this->request, function () {
             return $this->fulfilledPromise;
-        }, function () {
+        }, function (): void {
         });
 
         $this->assertCount(1, $this->currentStack->getProfiles());
@@ -145,22 +145,22 @@ class ProfilePluginTest extends TestCase
         $this->assertEquals(get_class($this->plugin), $profile->getPlugin());
     }
 
-    public function testCollectRequestInformations()
+    public function testCollectRequestInformations(): void
     {
         $this->subject->handleRequest($this->request, function () {
             return $this->fulfilledPromise;
-        }, function () {
+        }, function (): void {
         });
 
         $profile = $this->currentStack->getProfiles()[0];
         $this->assertEquals('FormattedRequest', $profile->getRequest());
     }
 
-    public function testOnFulfilled()
+    public function testOnFulfilled(): void
     {
         $promise = $this->subject->handleRequest($this->request, function () {
             return $this->fulfilledPromise;
-        }, function () {
+        }, function (): void {
         });
 
         $this->assertEquals($this->response, $promise->wait());
@@ -168,11 +168,11 @@ class ProfilePluginTest extends TestCase
         $this->assertEquals('FormattedResponse', $profile->getResponse());
     }
 
-    public function testOnRejected()
+    public function testOnRejected(): void
     {
         $promise = $this->subject->handleRequest($this->request, function () {
             return $this->rejectedPromise;
-        }, function () {
+        }, function (): void {
         });
 
         $this->expectException(TransferException::class);

--- a/tests/Unit/Collector/StackPluginTest.php
+++ b/tests/Unit/Collector/StackPluginTest.php
@@ -48,7 +48,7 @@ class StackPluginTest extends TestCase
      */
     private $subject;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->collector = $this->getMockBuilder(Collector::class)->disableOriginalConstructor()->getMock();
         $this->formatter = $this->getMockBuilder(Formatter::class)->disableOriginalConstructor()->getMock();
@@ -77,7 +77,7 @@ class StackPluginTest extends TestCase
         $this->subject = new StackPlugin($this->collector, $this->formatter, 'default');
     }
 
-    public function testStackIsInitialized()
+    public function testStackIsInitialized(): void
     {
         $this->collector
             ->expects($this->once())
@@ -98,11 +98,11 @@ class StackPluginTest extends TestCase
             return new FulfilledPromise($this->response);
         };
 
-        $this->subject->handleRequest($this->request, $next, function () {
+        $this->subject->handleRequest($this->request, $next, function (): void {
         });
     }
 
-    public function testOnFulfilled()
+    public function testOnFulfilled(): void
     {
         //Capture the current stack
         $currentStack = null;
@@ -123,7 +123,7 @@ class StackPluginTest extends TestCase
             return new FulfilledPromise($this->response);
         };
 
-        $promise = $this->subject->handleRequest($this->request, $next, function () {
+        $promise = $this->subject->handleRequest($this->request, $next, function (): void {
         });
 
         $this->assertEquals($this->response, $promise->wait());
@@ -131,7 +131,7 @@ class StackPluginTest extends TestCase
         $this->assertEquals('FormattedResponse', $currentStack->getResponse());
     }
 
-    public function testOnRejected()
+    public function testOnRejected(): void
     {
         //Capture the current stack
         $currentStack = null;
@@ -152,30 +152,30 @@ class StackPluginTest extends TestCase
             return new RejectedPromise($this->exception);
         };
 
-        $promise = $this->subject->handleRequest($this->request, $next, function () {
+        $promise = $this->subject->handleRequest($this->request, $next, function (): void {
         });
 
         $this->expectException(\Exception::class);
         $promise->wait();
     }
 
-    public function testOnException()
+    public function testOnException(): void
     {
         $this->collector
             ->expects($this->once())
             ->method('deactivateStack')
         ;
 
-        $next = function () {
+        $next = function (): void {
             throw new \Exception();
         };
 
         $this->expectException(\Exception::class);
-        $this->subject->handleRequest($this->request, $next, function () {
+        $this->subject->handleRequest($this->request, $next, function (): void {
         });
     }
 
-    public function testOnError()
+    public function testOnError(): void
     {
         $this->expectException(Warning::class);
 
@@ -188,7 +188,7 @@ class StackPluginTest extends TestCase
             return 2 / 0;
         };
 
-        $this->subject->handleRequest($this->request, $next, function () {
+        $this->subject->handleRequest($this->request, $next, function (): void {
         });
     }
 }

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -90,7 +90,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         return new Configuration(true);
     }
 
-    public function testEmptyConfiguration()
+    public function testEmptyConfiguration(): void
     {
         $formats = array_map(function ($path) {
             return __DIR__.'/../../Resources/Fixtures/'.$path;
@@ -105,7 +105,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         }
     }
 
-    public function testSupportsAllConfigFormats()
+    public function testSupportsAllConfigFormats(): void
     {
         $expectedConfiguration = [
             'default_client_autowiring' => false,
@@ -285,7 +285,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         }
     }
 
-    public function testMissingClass()
+    public function testMissingClass(): void
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/invalid_class.yml';
 
@@ -294,7 +294,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $this->assertProcessedConfigurationEquals([], [$file]);
     }
 
-    public function testInvalidPlugin()
+    public function testInvalidPlugin(): void
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/invalid_plugin.yml';
 
@@ -303,7 +303,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $this->assertProcessedConfigurationEquals([], [$file]);
     }
 
-    public function testInvalidAuthentication()
+    public function testInvalidAuthentication(): void
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/invalid_auth.yml';
 
@@ -315,7 +315,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
     /**
      * @group legacy
      */
-    public function testInvalidCacheConfig()
+    public function testInvalidCacheConfig(): void
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/invalid_cache_config.yml';
 
@@ -327,7 +327,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
     /**
      * @group legacy
      */
-    public function testBackwardCompatibility()
+    public function testBackwardCompatibility(): void
     {
         $formats = array_map(function ($path) {
             return __DIR__.'/../../Resources/Fixtures/'.$path;
@@ -344,7 +344,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
     /**
      * @group legacy
      */
-    public function testCacheConfigDeprecationCompatibility()
+    public function testCacheConfigDeprecationCompatibility(): void
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/bc/cache_config.yml';
         $config = $this->emptyConfig;
@@ -362,7 +362,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
     /**
      * @group legacy
      */
-    public function testCacheConfigDeprecationCompatibilityIssue166()
+    public function testCacheConfigDeprecationCompatibilityIssue166(): void
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/bc/issue-166.yml';
         $config = $this->emptyConfig;
@@ -377,7 +377,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $this->assertProcessedConfigurationEquals($config, [$file]);
     }
 
-    public function testProfilingToolbarCollision()
+    public function testProfilingToolbarCollision(): void
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/bc/profiling_toolbar.yml';
 
@@ -386,7 +386,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $this->assertProcessedConfigurationEquals([], [$file]);
     }
 
-    public function testClientCacheConfigMustHavePool()
+    public function testClientCacheConfigMustHavePool(): void
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/client_cache_config_with_no_pool.yml';
 
@@ -395,7 +395,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $this->assertProcessedConfigurationEquals([], [$file]);
     }
 
-    public function testCacheConfigMustHavePool()
+    public function testCacheConfigMustHavePool(): void
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/cache_config_with_no_pool.yml';
 
@@ -404,7 +404,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $this->assertProcessedConfigurationEquals([], [$file]);
     }
 
-    public function testLimitlessCapturedBodyLength()
+    public function testLimitlessCapturedBodyLength(): void
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/limitless_captured_body_length.yml';
         $config = $this->emptyConfig;
@@ -412,7 +412,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $this->assertProcessedConfigurationEquals($config, [$file]);
     }
 
-    public function testInvalidCapturedBodyLengthString()
+    public function testInvalidCapturedBodyLengthString(): void
     {
         $file = __DIR__.'/../../Resources/Fixtures/config/invalid_captured_body_length.yml';
 

--- a/tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -17,7 +17,7 @@ use Http\Adapter\Guzzle6\Client;
  */
 class HttplugExtensionTest extends AbstractExtensionTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -31,7 +31,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         ];
     }
 
-    public function testConfigLoadDefault()
+    public function testConfigLoadDefault(): void
     {
         $this->load();
 
@@ -40,7 +40,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         }
     }
 
-    public function testConfigLoadClass()
+    public function testConfigLoadClass(): void
     {
         $this->load([
             'classes' => [
@@ -51,7 +51,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService('httplug.client.default', Client::class);
     }
 
-    public function testConfigLoadService()
+    public function testConfigLoadService(): void
     {
         $this->load([
             'main_alias' => [
@@ -67,7 +67,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         }
     }
 
-    public function testClientPlugins()
+    public function testClientPlugins(): void
     {
         $this->load([
             'clients' => [
@@ -162,7 +162,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
     /**
      * @group legacy
      */
-    public function testNoProfilingWhenToolbarIsDisabled()
+    public function testNoProfilingWhenToolbarIsDisabled(): void
     {
         $this->load(
             [
@@ -181,7 +181,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         $this->verifyProfilingDisabled();
     }
 
-    public function testNoProfilingWhenNotInDebugMode()
+    public function testNoProfilingWhenNotInDebugMode(): void
     {
         $this->setParameter('kernel.debug', false);
         $this->load(
@@ -201,7 +201,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
     /**
      * @group legacy
      */
-    public function testProfilingWhenToolbarIsSpecificallyOn()
+    public function testProfilingWhenToolbarIsSpecificallyOn(): void
     {
         $this->setParameter('kernel.debug', false);
         $this->load(
@@ -221,7 +221,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService(PluginClientFactoryListener::class);
     }
 
-    public function testOverrideProfilingFormatter()
+    public function testOverrideProfilingFormatter(): void
     {
         $this->load(
             [
@@ -235,7 +235,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         $this->assertEquals('acme.formatter', (string) $def->getArgument(0));
     }
 
-    public function testCachePluginConfigCacheKeyGeneratorReference()
+    public function testCachePluginConfigCacheKeyGeneratorReference(): void
     {
         $this->load([
             'plugins' => [
@@ -256,7 +256,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         $this->assertSame('header_cache_key_generator', (string) $config['cache_key_generator']);
     }
 
-    public function testContentTypePluginAllowedOptions()
+    public function testContentTypePluginAllowedOptions(): void
     {
         $this->load([
             'clients' => [
@@ -282,7 +282,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         ], $config);
     }
 
-    public function testUsingServiceKeyForClients()
+    public function testUsingServiceKeyForClients(): void
     {
         $this->load([
             'clients' => [
@@ -297,7 +297,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         $this->assertFalse($client->isPublic());
     }
 
-    private function verifyProfilingDisabled()
+    private function verifyProfilingDisabled(): void
     {
         $def = $this->container->findDefinition('httplug.client');
         $this->assertTrue(is_subclass_of($def->getClass(), HttpClient::class));
@@ -311,7 +311,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         }
     }
 
-    public function testClientShouldHaveDefaultVisibility()
+    public function testClientShouldHaveDefaultVisibility(): void
     {
         $this->load([
             'clients' => [
@@ -331,7 +331,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         }
     }
 
-    public function testFlexibleClientShouldBePrivateByDefault()
+    public function testFlexibleClientShouldBePrivateByDefault(): void
     {
         $this->load([
             'clients' => [
@@ -345,7 +345,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         $this->assertFalse($this->container->getDefinition('httplug.client.acme.flexible')->isPublic());
     }
 
-    public function testHttpMethodsClientShouldBePrivateByDefault()
+    public function testHttpMethodsClientShouldBePrivateByDefault(): void
     {
         $this->load([
             'clients' => [
@@ -359,7 +359,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         $this->assertFalse($this->container->getDefinition('httplug.client.acme.http_methods')->isPublic());
     }
 
-    public function testBatchClientShouldBePrivateByDefault()
+    public function testBatchClientShouldBePrivateByDefault(): void
     {
         $this->load([
             'clients' => [
@@ -373,7 +373,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         $this->assertFalse($this->container->getDefinition('httplug.client.acme.batch_client')->isPublic());
     }
 
-    public function testClientCanBePublic()
+    public function testClientCanBePublic(): void
     {
         $this->load([
             'clients' => [
@@ -392,7 +392,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         }
     }
 
-    public function testFlexibleClientCanBePublic()
+    public function testFlexibleClientCanBePublic(): void
     {
         $this->load([
             'clients' => [
@@ -412,7 +412,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         }
     }
 
-    public function testHttpMethodsClientCanBePublic()
+    public function testHttpMethodsClientCanBePublic(): void
     {
         $this->load([
             'clients' => [
@@ -432,7 +432,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
         }
     }
 
-    public function testBatchClientCanBePublic()
+    public function testBatchClientCanBePublic(): void
     {
         $this->load([
             'clients' => [
@@ -456,7 +456,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
      * @dataProvider provideVcrPluginConfig
      * @group vcr-plugin
      */
-    public function testVcrPluginConfiguration(array $config, array $services, array $arguments = [])
+    public function testVcrPluginConfiguration(array $config, array $services, array $arguments = []): void
     {
         if (!class_exists(InMemoryRecorder::class)) {
             $this->markTestSkipped('VCR plugin is not installed.');
@@ -480,7 +480,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
     /**
      * @group vcr-plugin
      */
-    public function testIsNotLoadedUnlessNeeded()
+    public function testIsNotLoadedUnlessNeeded(): void
     {
         if (!class_exists(InMemoryRecorder::class)) {
             $this->markTestSkipped('VCR plugin is not installed.');

--- a/tests/Unit/Discovery/ConfiguredClientsStrategyTest.php
+++ b/tests/Unit/Discovery/ConfiguredClientsStrategyTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ConfiguredClientsStrategyTest extends TestCase
 {
-    public function testGetCandidates()
+    public function testGetCandidates(): void
     {
         $httpClient = $this->getMockBuilder(HttpClient::class)->getMock();
         $httpAsyncClient = $this->getMockBuilder(HttpAsyncClient::class)->getMock();
@@ -24,7 +24,7 @@ class ConfiguredClientsStrategyTest extends TestCase
         $this->assertEquals($httpAsyncClient, $candidate['class']());
     }
 
-    public function testGetCandidatesEmpty()
+    public function testGetCandidatesEmpty(): void
     {
         $strategy = new ConfiguredClientsStrategy(null, null);
 
@@ -35,7 +35,7 @@ class ConfiguredClientsStrategyTest extends TestCase
         $this->assertEquals([], $candidates);
     }
 
-    public function testGetCandidatesEmptyAsync()
+    public function testGetCandidatesEmptyAsync(): void
     {
         $httpClient = $this->getMockBuilder(HttpClient::class)->getMock();
         $strategy = new ConfiguredClientsStrategy($httpClient, null);
@@ -48,7 +48,7 @@ class ConfiguredClientsStrategyTest extends TestCase
         $this->assertEquals([], $candidates);
     }
 
-    public function testGetCandidatesEmptySync()
+    public function testGetCandidatesEmptySync(): void
     {
         $httpAsyncClient = $this->getMockBuilder(HttpAsyncClient::class)->getMock();
         $strategy = new ConfiguredClientsStrategy(null, $httpAsyncClient);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT

#### What's in this PR?

This PR

* [x] applies the `void_return` fixer to test code

I ran

```
$ php-cs-fixer fix --allow-risky=yes --diff --verbose --rules=void_return tests
```

#### Why?

We require at least PHP 7.1, so why not?

#### Todo

* [ ] Should we also apply this fixer to production code?