### PR TITLE
TypeError: Argument 1 passed to ProfileClient::collectExceptionInformations() must be an instance of Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 - Configured clients are now tagged with `'httplug.client'`
 
+### Changed
+
+- Fixed error handling. Now TypeErrors and other \Throwable are correctly handled by ProfileClient
+
 ## 1.16.0 - 2019-06-05
 
 ### Changed

--- a/src/Collector/Formatter.php
+++ b/src/Collector/Formatter.php
@@ -44,11 +44,11 @@ class Formatter implements MessageFormatter
     /**
      * Formats an exception.
      *
-     * @param Exception $exception
+     * @param \Throwable $exception
      *
      * @return string
      */
-    public function formatException(Exception $exception)
+    public function formatException(\Throwable $exception)
     {
         if ($exception instanceof HttpException) {
             return $this->formatter->formatResponse($exception->getResponse());

--- a/src/Collector/ProfileClient.php
+++ b/src/Collector/ProfileClient.php
@@ -176,11 +176,11 @@ class ProfileClient implements HttpClient, HttpAsyncClient
     }
 
     /**
-     * @param \Exception     $exception
+     * @param \Throwable     $exception
      * @param StopwatchEvent $event
      * @param Stack          $stack
      */
-    private function collectExceptionInformations(\Exception $exception, StopwatchEvent $event, Stack $stack)
+    private function collectExceptionInformations(\Throwable $exception, StopwatchEvent $event, Stack $stack)
     {
         if ($exception instanceof HttpException) {
             $this->collectResponseInformations($exception->getResponse(), $event, $stack);

--- a/tests/Unit/Collector/ProfileClientTest.php
+++ b/tests/Unit/Collector/ProfileClientTest.php
@@ -151,7 +151,7 @@ class ProfileClientTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('sendRequest')
-            ->willThrowException(new \TypeError('You set string to int prop'));
+            ->willThrowException(new \Error('You set string to int prop'));
 
         $response = $this->subject->sendRequest($this->request);
     }

--- a/tests/Unit/Collector/ProfileClientTest.php
+++ b/tests/Unit/Collector/ProfileClientTest.php
@@ -151,7 +151,9 @@ class ProfileClientTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('sendRequest')
-            ->willThrowException(new \Error('You set string to int prop'));
+            ->willReturnCallback(function () {
+                throw new \Error('You set string to int prop');
+            });
 
         $response = $this->subject->sendRequest($this->request);
     }

--- a/tests/Unit/Collector/ProfileClientTest.php
+++ b/tests/Unit/Collector/ProfileClientTest.php
@@ -14,6 +14,7 @@ use Http\HttplugBundle\Collector\Stack;
 use Http\Promise\FulfilledPromise;
 use Http\Promise\Promise;
 use Http\Promise\RejectedPromise;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -34,7 +35,7 @@ class ProfileClientTest extends TestCase
     private $activeStack;
 
     /**
-     * @var HttpClient
+     * @var HttpClient|MockObject
      */
     private $client;
 
@@ -143,6 +144,16 @@ class ProfileClientTest extends TestCase
         $this->assertEquals('/target', $this->activeStack->getRequestTarget());
         $this->assertEquals('example.com', $this->activeStack->getRequestHost());
         $this->assertEquals('https', $this->activeStack->getRequestScheme());
+    }
+
+    public function testSendRequestTypeError()
+    {
+        $this->client
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->willThrowException(new \TypeError('You set string to int prop'));
+
+        $response = $this->subject->sendRequest($this->request);
     }
 
     public function testSendAsyncRequest(): void

--- a/tests/Unit/Collector/ProfileClientTest.php
+++ b/tests/Unit/Collector/ProfileClientTest.php
@@ -45,7 +45,7 @@ class ProfileClientTest extends TestCase
     private $request;
 
     /**
-     * @var Formatter
+     * @var Formatter|MockObject
      */
     private $formatter;
 
@@ -111,11 +111,6 @@ class ProfileClientTest extends TestCase
             ->with($this->response)
             ->willReturn('FormattedResponse')
         ;
-        $this->formatter
-            ->method('formatException')
-            ->with($this->exception)
-            ->willReturn('FormattedException')
-        ;
 
         $this->stopwatch
             ->method('start')
@@ -146,6 +141,10 @@ class ProfileClientTest extends TestCase
         $this->assertEquals('https', $this->activeStack->getRequestScheme());
     }
 
+    /**
+     * @expectedException \Error
+     * @expectedException "You set string to int prop"
+     */
     public function testSendRequestTypeError()
     {
         $this->client
@@ -154,8 +153,12 @@ class ProfileClientTest extends TestCase
             ->willReturnCallback(function () {
                 throw new \Error('You set string to int prop');
             });
+        $this->formatter
+            ->expects($this->once())
+            ->method('formatException')
+            ->with($this->isInstanceOf(\Error::class));
 
-        $response = $this->subject->sendRequest($this->request);
+        $this->subject->sendRequest($this->request);
     }
 
     public function testSendAsyncRequest(): void
@@ -222,6 +225,12 @@ class ProfileClientTest extends TestCase
         $this->client
             ->method('sendAsyncRequest')
             ->willReturn($this->rejectedPromise)
+        ;
+
+        $this->formatter
+            ->method('formatException')
+            ->with($this->exception)
+            ->willReturn('FormattedException')
         ;
 
         $this->subject->sendAsyncRequest($this->request);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

Fix error 


#### Why?
```
TypeError: Argument 1 passed to Http\HttplugBundle\Collector\ProfileClient::collectExceptionInformations() must be an instance of Exception, instance of TypeError given, called in /home/spolischook/www/mobile-api/vendor/php-http/httplug-bundle/src/Collector/ProfileClient.php on line 144
```

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [] If the PR is not complete but you want to discuss the approach, list what remains to be done here
