### PR TITLE
Adds link to debug token.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 ### Added
 
 - Configured clients are now tagged with `'httplug.client'`
+- Adds a link to profiler page when response is from a Symfony application with
+  profiler enabled
 
 ## 1.16.0 - 2019-06-05
 

--- a/src/Collector/ProfileClient.php
+++ b/src/Collector/ProfileClient.php
@@ -173,6 +173,10 @@ class ProfileClient implements HttpClient, HttpAsyncClient
         $stack->setDuration($event->getDuration());
         $stack->setResponseCode($response->getStatusCode());
         $stack->setClientResponse($this->formatter->formatResponse($response));
+        if ($response->hasHeader('X-Debug-Token-Link')) {
+            $stack->setDebugToken($response->getHeaderLine('X-Debug-Token'));
+            $stack->setDebugTokenLink($response->getHeaderLine('X-Debug-Token-Link'));
+        }
     }
 
     /**

--- a/src/Collector/Stack.php
+++ b/src/Collector/Stack.php
@@ -82,6 +82,16 @@ final class Stack
     private $responseCode;
 
     /**
+     * @var string|null
+     */
+    private $debugToken;
+
+    /**
+     * @var string|null
+     */
+    private $debugTokenLink;
+
+    /**
      * @var int
      */
     private $duration = 0;
@@ -275,6 +285,38 @@ final class Stack
     public function setResponseCode($responseCode)
     {
         $this->responseCode = $responseCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDebugToken()
+    {
+        return $this->debugToken;
+    }
+
+    /**
+     * @param string $debugToken
+     */
+    public function setDebugToken($debugToken)
+    {
+        $this->debugToken = $debugToken;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDebugTokenLink()
+    {
+        return $this->debugTokenLink;
+    }
+
+    /**
+     * @param string $debugTokenLink
+     */
+    public function setDebugTokenLink($debugTokenLink)
+    {
+        $this->debugTokenLink = $debugTokenLink;
     }
 
     /**

--- a/src/Resources/views/stack.html.twig
+++ b/src/Resources/views/stack.html.twig
@@ -38,7 +38,7 @@
             {{ stack.clientRequest|httplug_markup|nl2br }}
         </div>
         <div class="httplug-message card">
-            <h4>Response</h4>
+            <h4>Response {% if stack.debugTokenLink %}<span class="label status-info"><a href="{{ stack.debugTokenLink }}">Debug Token: {{ stack.debugToken }}</a></span>{% endif %}</h4>
             {{ stack.clientResponse|httplug_markup|nl2br }}
         </div>
     </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

If a response contains a header `X-Debug-Token-Link`, i.e. a link to a Symfony debug toolbar profiler page, a clickable link is added to easily navigate to it.


#### Why?

This is purely for a more convenient debugging when investigating Responses from a (different) Symfony application.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

