### PR TITLE
[Profiler] Use tabular design for HTTP request/headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 ### Changed
 
 - Fixed error handling. Now TypeErrors and other \Throwable are correctly handled by ProfileClient
+- Use tabular design in profiler for HTTP request/response headers
+
+### Deprecated
+
+- `httplug.collector.twig.http_message` service
+- `httplug_markup` Twig function
 
 ## 1.16.0 - 2019-06-05
 

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "symfony/stopwatch": "^3.4.20 || ^4.2.1",
         "symfony/twig-bundle": "^3.4.20 || ^4.2.1",
         "symfony/web-profiler-bundle": "^3.4.20 || ^4.2.1",
-        "twig/twig": "^1.36 || ^2.6"
+        "twig/twig": "^1.41 || ^2.10"
     },
     "suggest": {
         "php-http/cache-plugin": "To configure clients that cache responses",

--- a/src/Collector/ProfileClient.php
+++ b/src/Collector/ProfileClient.php
@@ -173,10 +173,6 @@ class ProfileClient implements HttpClient, HttpAsyncClient
         $stack->setDuration($event->getDuration());
         $stack->setResponseCode($response->getStatusCode());
         $stack->setClientResponse($this->formatter->formatResponse($response));
-        if ($response->hasHeader('X-Debug-Token-Link')) {
-            $stack->setDebugToken($response->getHeaderLine('X-Debug-Token'));
-            $stack->setDebugTokenLink($response->getHeaderLine('X-Debug-Token-Link'));
-        }
     }
 
     /**

--- a/src/Collector/Stack.php
+++ b/src/Collector/Stack.php
@@ -82,16 +82,6 @@ final class Stack
     private $responseCode;
 
     /**
-     * @var string|null
-     */
-    private $debugToken;
-
-    /**
-     * @var string|null
-     */
-    private $debugTokenLink;
-
-    /**
      * @var int
      */
     private $duration = 0;
@@ -285,38 +275,6 @@ final class Stack
     public function setResponseCode($responseCode)
     {
         $this->responseCode = $responseCode;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDebugToken()
-    {
-        return $this->debugToken;
-    }
-
-    /**
-     * @param string $debugToken
-     */
-    public function setDebugToken($debugToken)
-    {
-        $this->debugToken = $debugToken;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDebugTokenLink()
-    {
-        return $this->debugTokenLink;
-    }
-
-    /**
-     * @param string $debugTokenLink
-     */
-    public function setDebugTokenLink($debugTokenLink)
-    {
-        $this->debugTokenLink = $debugTokenLink;
     }
 
     /**

--- a/src/Collector/Twig/HttpMessageMarkupExtension.php
+++ b/src/Collector/Twig/HttpMessageMarkupExtension.php
@@ -24,6 +24,8 @@ class HttpMessageMarkupExtension extends \Twig_Extension
      */
     public function markup($message)
     {
+        @trigger_error('"httplug_markup" twig extension is deprecated since version 1.17 and will be removed in 2.0. Use "@Httplug/http_message.html.twig" template instead.', E_USER_DEPRECATED);
+
         $safeMessage = htmlentities($message);
         $parts = preg_split('|\\r?\\n\\r?\\n|', $safeMessage, 2);
 

--- a/src/Resources/config/data-collector.xml
+++ b/src/Resources/config/data-collector.xml
@@ -24,6 +24,7 @@
 
         <service id="httplug.collector.twig.http_message" class="Http\HttplugBundle\Collector\Twig\HttpMessageMarkupExtension" public="false">
             <tag name="twig.extension" />
+            <deprecated>The %service_id% service is deprecated since version 1.17 and will be removed in 2.0. Use "@Httplug/http_message.html.twig" template instead.</deprecated>
         </service>
 
         <!-- Discovered clients -->

--- a/src/Resources/views/http_message.html.twig
+++ b/src/Resources/views/http_message.html.twig
@@ -1,0 +1,29 @@
+{% set hasReachedBody = false %}
+{% set content = '' %}
+{% set data = data|split("\n")|slice(1) %}
+{% set xdebugTokenLink = data|filter(v => 'x-debug-token-link:' in v|lower)|first|split(': ')|last %}
+
+<table>
+    <thead>
+    <tr>
+        <th scope="col" class="key" colspan="2">{{ header }}{% if xdebugTokenLink %} <span style="float:right"><a href="{{ xdebugTokenLink }}">Profile link</a></span>{% endif %}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for row in data %}
+        {% if row is empty %}
+            {% set hasReachedBody = true %}
+        {% elseif hasReachedBody %}
+            {% set content = content ~ "\n" ~ row %}
+        {% else %}
+            {% set row = row|split(':') %}
+            <tr>
+                <th>{{ row[0] }}</th>
+                <td>{{ row|slice(1)|join(':')|trim }}</td>
+            </tr>
+        {% endif %}
+    {% endfor %}
+    </tbody>
+</table>
+
+<div class='httplug-http-body httplug-hidden'>{{ content|nl2br ?: '(This message has no captured body)' }}</div>

--- a/src/Resources/views/stack.html.twig
+++ b/src/Resources/views/stack.html.twig
@@ -34,12 +34,10 @@
     </div>
     <div class="httplug-messages">
         <div class="httplug-message card">
-            <h4>Request</h4>
-            {{ stack.clientRequest|httplug_markup|nl2br }}
+            {% include '@Httplug/http_message.html.twig' with { data: stack.clientRequest, header: 'Request' } only %}
         </div>
         <div class="httplug-message card">
-            <h4>Response {% if stack.debugTokenLink %}<span class="label status-info"><a href="{{ stack.debugTokenLink }}">Debug Token: {{ stack.debugToken }}</a></span>{% endif %}</h4>
-            {{ stack.clientResponse|httplug_markup|nl2br }}
+            {% include '@Httplug/http_message.html.twig' with { data: stack.clientResponse, header: 'Response' } only %}
         </div>
     </div>
     {% if stack.profiles %}
@@ -48,12 +46,10 @@
                 <h3 class="httplug-plugin-name">{{ profile.plugin }}</h3>
                 <div class="httplug-messages">
                     <div class="httplug-message">
-                        <h4>Request</h4>
-                        {{ profile.request|httplug_markup|nl2br }}
+                        {% include '@Httplug/http_message.html.twig' with { data: profile.request, header: 'Request' } only %}
                     </div>
                     <div class="httplug-message">
-                        <h4>Response</h4>
-                        {{ profile.response|httplug_markup|nl2br }}
+                        {% include '@Httplug/http_message.html.twig' with { data: profile.response, header: 'Response' } only %}
                     </div>
                 </div>
                 {% if not loop.last %}

--- a/tests/Functional/ProfilerTest.php
+++ b/tests/Functional/ProfilerTest.php
@@ -6,6 +6,9 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class ProfilerTest extends WebTestCase
 {
+    /**
+     * @group legacy
+     */
     public function testShowProfiler(): void
     {
         $client = static::createClient();

--- a/tests/Functional/ServiceInstantiationTest.php
+++ b/tests/Functional/ServiceInstantiationTest.php
@@ -42,6 +42,9 @@ class ServiceInstantiationTest extends WebTestCase
         $this->assertInstanceOf(HttpClient::class, $client);
     }
 
+    /**
+     * @group legacy
+     */
     public function testDebugToolbar(): void
     {
         static::bootKernel(['debug' => true]);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | partially #245
| Documentation   |
| License         | MIT


#### What's in this PR and why?

Improved profiler design. Check [Before](https://user-images.githubusercontent.com/496233/69001989-3605b500-08e8-11ea-90b2-9a1c7b6d0b3f.png) and [After](https://user-images.githubusercontent.com/496233/69001956-dc9d8600-08e7-11ea-91a0-f44dad85a106.png). Also check linked issue.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### Out of scope
- `<t(d|h)>` text trimming. I just want to make this simple first time. This can be added in future, at this time horizontal scrolling works perfect here.
- Syntax highlighting for body. Should be done in separate PR, I want to minimze scope here which will help review and merge this faster.