### PR TITLE
do not fail with twig 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## Unreleased
 
+### Fixed
+
+- Avoid conflict with Twig 3.
+
 ### Added
 
 - Configured clients are now tagged with `'httplug.client'`

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "symfony/stopwatch": "^3.4.20 || ^4.2.1",
         "symfony/twig-bundle": "^3.4.20 || ^4.2.1",
         "symfony/web-profiler-bundle": "^3.4.20 || ^4.2.1",
-        "twig/twig": "^1.41 || ^2.10"
+        "twig/twig": "^1.41 || ^2.10 || ^3.0"
     },
     "suggest": {
         "php-http/cache-plugin": "To configure clients that cache responses",

--- a/src/Collector/Twig/HttpMessageMarkupExtension.php
+++ b/src/Collector/Twig/HttpMessageMarkupExtension.php
@@ -2,10 +2,20 @@
 
 namespace Http\HttplugBundle\Collector\Twig;
 
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+if (!\class_exists(AbstractExtension::class)) {
+    class_alias(\Twig_Extension::class, AbstractExtension::class);
+}
+if (!\class_exists(TwigFilter::class)) {
+    class_alias(\Twig_SimpleFilter::class, TwigFilter::class);
+}
+
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class HttpMessageMarkupExtension extends \Twig_Extension
+class HttpMessageMarkupExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}
@@ -15,7 +25,7 @@ class HttpMessageMarkupExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('httplug_markup', [$this, 'markup'], ['is_safe' => ['html']]),
+            new TwigFilter('httplug_markup', [$this, 'markup'], ['is_safe' => ['html']]),
         ];
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #358
| Documentation   | -
| License         | MIT


#### What's in this PR?

Make sure our twig extension works with twig 3.


#### Why?

We did not declare a conflict with twig 3, so the bundle can be installed alongside twig 3.
