### PR TITLE
Add a Symfony client factory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ matrix:
         - php: 7.3
           env: SYMFONY_REQUIRE=4.3.*
         - php: 7.3
-          env: SYMFONY_REQUIRE=4.4.*
+          env: SYMFONY_REQUIRE=4.4.* DEPENDENCIES="symfony/http-client:^4.4"
         - php: 7.3
-          env: SYMFONY_REQUIRE=5.0.*
+          env: SYMFONY_REQUIRE=5.0.* DEPENDENCIES="symfony/http-client:^5.0"
 
           # Test with httplug 1.x clients
         - php: 7.2

--- a/src/ClientFactory/SymfonyFactory.php
+++ b/src/ClientFactory/SymfonyFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Http\HttplugBundle\ClientFactory;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\HttplugClient;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class SymfonyFactory implements ClientFactory
+{
+    /**
+     * @var ResponseFactoryInterface
+     */
+    private $responseFactory;
+
+    /**
+     * @var StreamFactoryInterface
+     */
+    private $streamFactory;
+
+    /**
+     * @param ResponseFactoryInterface $responseFactory
+     * @param StreamFactoryInterface   $streamFactory
+     */
+    public function __construct(ResponseFactoryInterface $responseFactory, StreamFactoryInterface $streamFactory)
+    {
+        $this->responseFactory = $responseFactory;
+        $this->streamFactory = $streamFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createClient(array $config = [])
+    {
+        if (!class_exists(HttplugClient::class)) {
+            throw new \LogicException('To use the Symfony client you need to install the "symfony/http-client" package.');
+        }
+
+        return new HttplugClient(HttpClient::create($config), $this->responseFactory, $this->streamFactory);
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -93,5 +93,9 @@
         <service id="httplug.factory.socket" class="Http\HttplugBundle\ClientFactory\SocketFactory" public="false">
             <argument type="service" id="httplug.message_factory"/>
         </service>
+        <service id="httplug.factory.symfony" class="Http\HttplugBundle\ClientFactory\SymfonyFactory" public="false">
+            <argument type="service" id="httplug.psr17_response_factory"/>
+            <argument type="service" id="httplug.psr17_stream_factory"/>
+        </service>
     </services>
 </container>

--- a/tests/Unit/ClientFactory/SymfonyFactoryTest.php
+++ b/tests/Unit/ClientFactory/SymfonyFactoryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Http\HttplugBundle\Tests\Unit\ClientFactory;
+
+use Http\HttplugBundle\ClientFactory\SymfonyFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Symfony\Component\HttpClient\HttplugClient;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class SymfonyFactoryTest extends TestCase
+{
+    public function testCreateClient(): void
+    {
+        if (!class_exists(HttplugClient::class)) {
+            $this->markTestSkipped('Symfony Http client is not installed');
+        }
+
+        $factory = new SymfonyFactory(
+            $this->getMockBuilder(ResponseFactoryInterface::class)->getMock(),
+            $this->getMockBuilder(StreamFactoryInterface::class)->getMock()
+        );
+        $client = $factory->createClient();
+
+        $this->assertInstanceOf(HttplugClient::class, $client);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT

This PR is blocked by #372. It will allow you to configure Symfony clients like: 

```yaml
httplug:
    clients:
        default:
            factory: 'httplug.factory.symfony'
            http_methods_client: true
            config:
                timeout: 4  # Symfony config
            plugins:
                - 'httplug.plugin.logger'

```