### PR TITLE
replace the include tag with the include() function

### DIFF
--- a/src/Resources/views/stack.html.twig
+++ b/src/Resources/views/stack.html.twig
@@ -34,10 +34,10 @@
     </div>
     <div class="httplug-messages">
         <div class="httplug-message card">
-            {% include '@Httplug/http_message.html.twig' with { data: stack.clientRequest, header: 'Request' } only %}
+            {{ include('@Httplug/http_message.html.twig', { data: stack.clientRequest, header: 'Request' }, with_context=false) }}
         </div>
         <div class="httplug-message card">
-            {% include '@Httplug/http_message.html.twig' with { data: stack.clientResponse, header: 'Response' } only %}
+            {{ include('@Httplug/http_message.html.twig', { data: stack.clientResponse, header: 'Response' }, with_context=false) }}
         </div>
     </div>
     {% if stack.profiles %}
@@ -46,10 +46,10 @@
                 <h3 class="httplug-plugin-name">{{ profile.plugin }}</h3>
                 <div class="httplug-messages">
                     <div class="httplug-message">
-                        {% include '@Httplug/http_message.html.twig' with { data: profile.request, header: 'Request' } only %}
+                        {{ include('@Httplug/http_message.html.twig', { data: profile.request, header: 'Request' }, with_context=false) }}
                     </div>
                     <div class="httplug-message">
-                        {% include '@Httplug/http_message.html.twig' with { data: profile.response, header: 'Response' } only %}
+                        {{ include('@Httplug/http_message.html.twig', { data: profile.response, header: 'Response' }, with_context=false) }}
                     </div>
                 </div>
                 {% if not loop.last %}
@@ -61,11 +61,11 @@
 </div>
 {% for child in collector.childrenStacks(stack) %}
     <div class="httplug-stack">
-        {% include '@Httplug/stack.html.twig' with {
+        {{ include('@Httplug/stack.html.twig', {
             'collector': collector,
             'client': client,
             'stack': child,
             'id': id ~ '-' ~ loop.index
-        } only %}
+        }, with_context=false) }}
     </div>
 {% endfor %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   |
| License         | MIT


#### What's in this PR?

Replaces usages of the Twig `include` tag with the `include()` function.


#### Why?

Twig best practice is to use the function instead of the tag:

> It is recommended to use the include function instead as it provides the same features with a bit more flexibility [...]

see https://twig.symfony.com/doc/3.x/tags/include.html