### PR TITLE
make plugin service templates abstract to avoid warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 - Allow to configure cache listeners on the cache plugin
 
 ### Changed
-- tests are excluded from zip releases
+
+- Tests are excluded from zip releases
+- Define plugin service templates as abstract to avoid warnings from Symfony
 
 ## 1.17.0 - 2019-12-27
 

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -216,7 +216,9 @@ class HttplugExtension extends Extension
                 $definition
                     ->replaceArgument(0, new Reference($config['cache_pool']))
                     ->replaceArgument(1, new Reference($config['stream_factory']))
-                    ->replaceArgument(2, $options);
+                    ->replaceArgument(2, $options)
+                    ->setAbstract(false)
+                ;
 
                 break;
 
@@ -242,6 +244,7 @@ class HttplugExtension extends Extension
                 if (!empty($config['formatter'])) {
                     $definition->replaceArgument(1, new Reference($config['formatter']));
                 }
+                $definition->setAbstract(false);
 
                 break;
 
@@ -261,7 +264,10 @@ class HttplugExtension extends Extension
                 break;
 
             case 'stopwatch':
-                $definition->replaceArgument(0, new Reference($config['stopwatch']));
+                $definition
+                    ->replaceArgument(0, new Reference($config['stopwatch']))
+                    ->setAbstract(false)
+                ;
 
                 break;
 

--- a/src/Resources/config/plugins.xml
+++ b/src/Resources/config/plugins.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="httplug.plugin.cache" class="Http\Client\Common\Plugin\CachePlugin" public="false">
+        <service id="httplug.plugin.cache" class="Http\Client\Common\Plugin\CachePlugin" public="false" abstract="true">
             <argument />
             <argument />
             <argument />
@@ -18,13 +18,13 @@
         <service id="httplug.plugin.history" class="Http\Client\Common\Plugin\HistoryPlugin" public="false">
             <argument />
         </service>
-        <service id="httplug.plugin.logger" class="Http\Client\Common\Plugin\LoggerPlugin" public="false">
+        <service id="httplug.plugin.logger" class="Http\Client\Common\Plugin\LoggerPlugin" public="false" abstract="true">
             <argument />
             <argument>null</argument>
         </service>
         <service id="httplug.plugin.redirect" class="Http\Client\Common\Plugin\RedirectPlugin" public="false" />
         <service id="httplug.plugin.retry" class="Http\Client\Common\Plugin\RetryPlugin" public="false" />
-        <service id="httplug.plugin.stopwatch" class="Http\Client\Common\Plugin\StopwatchPlugin" public="false">
+        <service id="httplug.plugin.stopwatch" class="Http\Client\Common\Plugin\StopwatchPlugin" public="false" abstract="true">
             <argument />
         </service>
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Make plugin service templates abstract


#### Why?

Avoid warning from Symfony