### PR TITLE
test lowest version with lowest supported php version, not highest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ branches:
 matrix:
     fast_finish: true
     include:
-          # Minimum supported Symfony version and latest PHP version
-        - php: 7.4
+          # Minimum supported Symfony version and lowest PHP version
+        - php: 7.2
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
 
           # Test the latest stable release


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | trying to reproduce #385
| Documentation   | 
| License         | MIT


#### What's in this PR?

Lowest version build should be done with lowest supported PHP version, as we otherwise might accidentally install a newer version of a package because the oldest allowed version does not support a newer PHP version.

