### PR TITLE
Split listener from ConfiguredClientsStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 1.19.0 - unreleased
+
+### Changed
+
+- `ConfiguredClientsStrategy` no longer implements `EventSubscriberInterface`,
+  this has been moved to `ConfiguredClientsStrategyListener` to avoid initializing
+  the strategy on every request.
+
 ## 1.18.0 - 2020-03-30
 
 ### Added

--- a/src/Discovery/ConfiguredClientsStrategy.php
+++ b/src/Discovery/ConfiguredClientsStrategy.php
@@ -8,16 +8,6 @@ use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Strategy\DiscoveryStrategy;
-use Symfony\Component\EventDispatcher\Event as LegacyEvent;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Contracts\EventDispatcher\Event;
-
-if (Kernel::MAJOR_VERSION >= 5) {
-    \class_alias(Event::class, 'Http\HttplugBundle\Discovery\ConfiguredClientsStrategyEventClass');
-} else {
-    \class_alias(LegacyEvent::class, 'Http\HttplugBundle\Discovery\ConfiguredClientsStrategyEventClass');
-}
 
 /**
  * A strategy that provide clients configured with HTTPlug bundle. With help from this strategy
@@ -25,7 +15,7 @@ if (Kernel::MAJOR_VERSION >= 5) {
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class ConfiguredClientsStrategy implements DiscoveryStrategy, EventSubscriberInterface
+class ConfiguredClientsStrategy implements DiscoveryStrategy
 {
     /**
      * @var HttpClient
@@ -66,26 +56,5 @@ class ConfiguredClientsStrategy implements DiscoveryStrategy, EventSubscriberInt
         }
 
         return [];
-    }
-
-    /**
-     * Make sure to use our custom strategy.
-     */
-    public function onEvent(ConfiguredClientsStrategyEventClass $e)
-    {
-        HttpClientDiscovery::prependStrategy(self::class);
-    }
-
-    /**
-     * Whenever these events occur we make sure to add our strategy to the discovery.
-     *
-     * {@inheritdoc}
-     */
-    public static function getSubscribedEvents()
-    {
-        return [
-            'kernel.request' => ['onEvent', 1024],
-            'console.command' => ['onEvent', 1024],
-        ];
     }
 }

--- a/src/Discovery/ConfiguredClientsStrategyListener.php
+++ b/src/Discovery/ConfiguredClientsStrategyListener.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\HttplugBundle\Discovery;
+
+use Http\Discovery\HttpClientDiscovery;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class ConfiguredClientsStrategyListener implements EventSubscriberInterface
+{
+    /**
+     * Make sure to use the custom strategy.
+     */
+    public function onEvent()
+    {
+        HttpClientDiscovery::prependStrategy(ConfiguredClientsStrategy::class);
+    }
+
+    /**
+     * Whenever these events occur we make sure to add the custom strategy to the discovery.
+     *
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            'kernel.request' => ['onEvent', 1024],
+            'console.command' => ['onEvent', 1024],
+        ];
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,6 +7,9 @@
         <service id="httplug.strategy" class="Http\HttplugBundle\Discovery\ConfiguredClientsStrategy">
             <argument type="service" id="httplug.auto_discovery.auto_discovered_client" on-invalid="null"/>
             <argument type="service" id="httplug.auto_discovery.auto_discovered_async" on-invalid="null"/>
+        </service>
+
+        <service id="httplug.strategy_listener" class="Http\HttplugBundle\Discovery\ConfiguredClientsStrategyListener">
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/tests/Functional/DiscoveredClientsTest.php
+++ b/tests/Functional/DiscoveredClientsTest.php
@@ -10,12 +10,9 @@ use Http\Discovery\HttpAsyncClientDiscovery;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Strategy\CommonClassesStrategy;
 use Http\HttplugBundle\Collector\ProfileClient;
-use Http\HttplugBundle\Discovery\ConfiguredClientsStrategy;
+use Http\HttplugBundle\Discovery\ConfiguredClientsStrategyListener;
 use Nyholm\NSA;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\EventDispatcher\Event as LegacyEvent;
-use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Contracts\EventDispatcher\Event;
 
 class DiscoveredClientsTest extends WebTestCase
 {
@@ -128,9 +125,8 @@ class DiscoveredClientsTest extends WebTestCase
         parent::setUp();
 
         // Reset values
-        $strategy = new ConfiguredClientsStrategy(null, null);
+        $strategy = new ConfiguredClientsStrategyListener(null, null);
         HttpClientDiscovery::setStrategies([CommonClassesStrategy::class]);
-        $class = (Kernel::MAJOR_VERSION >= 5) ? Event::class : LegacyEvent::class;
-        $strategy->onEvent(new $class());
+        $strategy->onEvent();
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | technically speaking yes (but I would assume this class should be considered internal?)
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

This splits the listener from the `ConfiguredClientsStrategy`.


#### Why?

The listener only executes a static call. This avoids initializing the dependencies (including HttpClient) on each request/command call.


#### Checklist

Not sure if any of these checks should be done for this PR?

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)