### PR TITLE
Register client alias to support Symfony 5.3 Target attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# UNRELEASED
+
+- Added support for [Target attribute](https://symfony.com/blog/new-in-symfony-5-3-service-autowiring-with-attributes)
+  available in Symfony 5.3
+
 # 1.20.1 - 2021-02-12
 
 - Added `kernel.reset` tag to the Collector.

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -381,6 +381,10 @@ class HttplugExtension extends Extension
     {
         $serviceId = 'httplug.client.'.$clientName;
 
+        if (method_exists($container, 'registerAliasForArgument')) {
+            $container->registerAliasForArgument($serviceId, HttpClient::class, $clientName);
+        }
+
         $plugins = [];
         foreach ($arguments['plugins'] as $plugin) {
             $pluginName = key($plugin);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

When you are using Symfony 5.3 and you have multiple clients defined, you can use the `Target`
attribute to select the client that you want.

#### Why?

Improve Developer Experience.

#### Example Usage

Example:
```php
final class MyService
{
    public function __construct(
        #[Target('my_client_alias')] 
        HttpClient $client
    ) {}
}
```

It will now automatically inject `httplug.client.my_client_alias`.

For more information:
https://symfony.com/blog/new-in-symfony-5-3-service-autowiring-with-attributes

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
