### PR TITLE
Use `ClientInterface` instead of `HttpClient` interface when registering aliases

### DIFF
--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -383,8 +383,10 @@ class HttplugExtension extends Extension
         $serviceId = 'httplug.client.'.$clientName;
 
         if (method_exists($container, 'registerAliasForArgument')) {
-            $container->registerAliasForArgument($serviceId, HttpClient::class, $clientName);
+            $alias = $container->registerAliasForArgument($serviceId, HttpClient::class, $clientName);
             if (interface_exists(ClientInterface::class)) {
+                $alias->setDeprecated('php-http/httplug-bundle', '1.22', 'The "%alias_id%" alias is deprecated, use "Psr\Http\Client\ClientInterface" instead.');
+
                 $container->registerAliasForArgument($serviceId, ClientInterface::class, $clientName);
             }
         }

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -384,7 +384,9 @@ class HttplugExtension extends Extension
 
         if (method_exists($container, 'registerAliasForArgument')) {
             $alias = $container->registerAliasForArgument($serviceId, HttpClient::class, $clientName);
-            if (interface_exists(ClientInterface::class)) {
+
+            $interfaces = class_implements(HttpClient::class) ?? [];
+            if (isset($interfaces[ClientInterface::class])) {
                 $alias->setDeprecated('php-http/httplug-bundle', '1.22', 'The "%alias_id%" alias is deprecated, use "Psr\Http\Client\ClientInterface" instead.');
 
                 $container->registerAliasForArgument($serviceId, ClientInterface::class, $clientName);

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -21,6 +21,7 @@ use Http\Message\Authentication\Bearer;
 use Http\Message\Authentication\QueryParam;
 use Http\Message\Authentication\Wsse;
 use Http\Mock\Client as MockClient;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\UriInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
@@ -383,6 +384,9 @@ class HttplugExtension extends Extension
 
         if (method_exists($container, 'registerAliasForArgument')) {
             $container->registerAliasForArgument($serviceId, HttpClient::class, $clientName);
+            if (interface_exists(ClientInterface::class)) {
+                $container->registerAliasForArgument($serviceId, ClientInterface::class, $clientName);
+            }
         }
 
         $plugins = [];


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   |yes
| Related tickets | 
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

After https://github.com/php-http/HttplugBundle/pull/393 was merged I started using it in my project and soon discovered that `HttpClient` is deprecated and that the `ClientInterface` from Psr should be used instead.

#### Why?

This will deprecate the alias registration for HttpClient when the ClientInterface is found. 

It will also register the alias for the ClientInterface.


