### PR TITLE
Do not deprecate alias as it changed a lot in different Symfony versions

### DIFF
--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -387,8 +387,6 @@ class HttplugExtension extends Extension
 
             $interfaces = class_implements(HttpClient::class) ?? [];
             if (isset($interfaces[ClientInterface::class])) {
-                $alias->setDeprecated('php-http/httplug-bundle', '1.22', 'The "%alias_id%" alias is deprecated, use "Psr\Http\Client\ClientInterface" instead.');
-
                 $container->registerAliasForArgument($serviceId, ClientInterface::class, $clientName);
             }
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | see #394
| Documentation   | 
| License         | MIT


#### What's in this PR?

Turns out that `Alias::setDeprecated` changed a lot between Symfony versions. I couldn't find a way to distinguish between them so decided to just remove the deprecation for now.
