### PR TITLE
[Profiler] Utilize symfony/var-dumper for dumping response body 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# 1.23.0 - ?
+
+- Changed the way request/response body is displayed in profiler. symfony/var-dumper is used now.
+
 # 1.22.1 - 2021-07-26
 
 - Do not deprecate the service alias for the old Http\Client\HttpClient interface because different Symfony

--- a/src/Resources/config/data-collector.xml
+++ b/src/Resources/config/data-collector.xml
@@ -24,6 +24,8 @@
         </service>
 
         <service id="httplug.collector.twig.http_message" class="Http\HttplugBundle\Collector\Twig\HttpMessageMarkupExtension" public="false">
+            <argument type="service" id="var_dumper.cloner" on-invalid="null" />
+            <argument type="service" id="var_dumper.html_dumper" on-invalid="null" />
             <tag name="twig.extension" />
         </service>
 

--- a/src/Resources/views/http_message.html.twig
+++ b/src/Resources/views/http_message.html.twig
@@ -14,7 +14,7 @@
         {% if row is empty %}
             {% set hasReachedBody = true %}
         {% elseif hasReachedBody %}
-            {% set content = content ~ "\n" ~ row %}
+            {% set content = content ~ row %}
         {% else %}
             {% set row = row|split(':') %}
             {% set value = row|slice(1)|join(':')|trim %}
@@ -33,4 +33,4 @@
     </tbody>
 </table>
 
-<div class='httplug-http-body httplug-hidden'>{{ content|nl2br ?: '(This message has no captured body)' }}</div>
+<div class='httplug-http-body httplug-hidden'>{{ content|httplug_markup_body }}</div>

--- a/src/Resources/views/http_message.html.twig
+++ b/src/Resources/views/http_message.html.twig
@@ -33,4 +33,4 @@
     </tbody>
 </table>
 
-<div class='httplug-http-body httplug-hidden'>{{ content|httplug_markup_body }}</div>
+<div class='httplug-http-body httplug-hidden'>{{ content ? content|httplug_markup_body : '(This message has no captured body)' }}</div>

--- a/tests/Functional/DiscoveredClientsTest.php
+++ b/tests/Functional/DiscoveredClientsTest.php
@@ -19,7 +19,7 @@ class DiscoveredClientsTest extends WebTestCase
 {
     public function testDiscoveredClient(): void
     {
-        $container = $this->getContainer(false);
+        $container = $this->getCustomContainer(false);
 
         $this->assertTrue($container->has('httplug.auto_discovery.auto_discovered_client'));
 
@@ -30,7 +30,7 @@ class DiscoveredClientsTest extends WebTestCase
 
     public function testDiscoveredAsyncClient(): void
     {
-        $container = $this->getContainer(false);
+        $container = $this->getCustomContainer(false);
 
         $this->assertTrue($container->has('httplug.auto_discovery.auto_discovered_async'));
 
@@ -41,7 +41,7 @@ class DiscoveredClientsTest extends WebTestCase
 
     public function testDiscoveredClientWithProfilingEnabled(): void
     {
-        $container = $this->getContainer(true);
+        $container = $this->getCustomContainer(true);
 
         $this->assertTrue($container->has('httplug.auto_discovery.auto_discovered_client'));
 
@@ -53,7 +53,7 @@ class DiscoveredClientsTest extends WebTestCase
 
     public function testDiscoveredAsyncClientWithProfilingEnabled(): void
     {
-        $container = $this->getContainer(true);
+        $container = $this->getCustomContainer(true);
 
         $this->assertTrue($container->has('httplug.auto_discovery.auto_discovered_async'));
 
@@ -68,7 +68,7 @@ class DiscoveredClientsTest extends WebTestCase
      */
     public function testDiscovery(): void
     {
-        $container = $this->getContainer(true);
+        $container = $this->getCustomContainer(true);
 
         $this->assertTrue($container->has('httplug.auto_discovery.auto_discovered_client'));
         $this->assertTrue($container->has('httplug.auto_discovery.auto_discovered_async'));
@@ -90,7 +90,7 @@ class DiscoveredClientsTest extends WebTestCase
      */
     public function testDisabledDiscovery(): void
     {
-        $container = $this->getContainer(true, 'discovery_disabled');
+        $container = $this->getCustomContainer(true, 'discovery_disabled');
 
         $this->assertFalse($container->has('httplug.auto_discovery.auto_discovered_client'));
         $this->assertFalse($container->has('httplug.auto_discovery.auto_discovered_async'));
@@ -106,7 +106,7 @@ class DiscoveredClientsTest extends WebTestCase
             $this->markTestSkipped('Guzzle7 adapter is not installed');
         }
 
-        $container = $this->getContainer(true, 'discovery_forced');
+        $container = $this->getCustomContainer(true, 'discovery_forced');
 
         $this->assertFalse($container->has('httplug.auto_discovery.auto_discovered_client'));
         $this->assertFalse($container->has('httplug.auto_discovery.auto_discovered_async'));
@@ -118,7 +118,7 @@ class DiscoveredClientsTest extends WebTestCase
         $this->assertEquals($container->get('httplug.client.acme'), HttpAsyncClientDiscovery::find());
     }
 
-    private function getContainer($debug, $environment = 'test')
+    private function getCustomContainer($debug, $environment = 'test')
     {
         static::bootKernel(['debug' => $debug, 'environment' => $environment]);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | finishes #245
| Documentation   | 
| License         | MIT


#### What's in this PR?

Similarly like `symfony/http-client` and other bundles, this utilizes `symfony/var-dumper` to format request/response body messages.

Json detection was partially taken over from [csa/guzzle-bundle](https://github.com/csarrazi/CsaGuzzleBundle/blob/master/src/Twig/Extension/GuzzleExtension.php#L52)

This results in much improved design of body formatting, replacing plain nl2br that was used till now.

![image](https://user-images.githubusercontent.com/496233/131198186-62a5776b-ec0a-43d2-a382-ea70d16f0ff9.png)



#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] CI https://app.travis-ci.com/github/ostrolucky/HttplugBundle/builds/236415878
- [ ] Documentation pull request created (if not simply a bugfix)