### PR TITLE
[Profiler] Always show badge with request count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
-# 1.23.0 - ?
+# 1.23.0 - 2021-08-30
 
 - Changed the way request/response body is displayed in profiler. symfony/var-dumper is used now.
+- Changed badge counter of # of requests on side menu to be always visible
 
 # 1.22.1 - 2021-07-26
 

--- a/src/Resources/views/webprofiler.html.twig
+++ b/src/Resources/views/webprofiler.html.twig
@@ -62,11 +62,9 @@
             {{ include('@Httplug/Icon/httplug.svg') }}
         </span>
         <strong>Httplug</strong>
-        {% if collector.failedStacks|length %}
-            <span class="count">
-                <span>{{ collector.failedStacks|length }}</span>
-            </span>
-        {% endif %}
+        <span class="count">
+            <span>{{ (collector.stacks|length - collector.failedStacks|length) ~ '/' ~ collector.stacks|length}}</span>
+        </span>
     </span>
 {% endblock %}
 


### PR DESCRIPTION
Count here is similarly important like number of queries that doctrine-bundle shows, so it should be also displayed at all times

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Always shows badge counter here instead of only when there are errors

![image](https://user-images.githubusercontent.com/496233/131308299-ff1eb6eb-3b4a-4870-a027-387f2b97d071.png)


#### Why?

This info is always important, similarly like # of queries in ORM - people should try to keep it low

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
