### PR TITLE
Fix issue with whitespaces in URL when URL in tab was copied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# 1.23.1
+- Fix issue with whitespaces in URL when URL in tab was copied
+
 # 1.23.0 - 2021-08-30
 
 - Changed the way request/response body is displayed in profiler. symfony/var-dumper is used now.

--- a/src/Resources/views/stack.html.twig
+++ b/src/Resources/views/stack.html.twig
@@ -7,11 +7,13 @@
         {% endif %}
         <span class="label httplug-method httplug-method-{{ stack.requestMethod|lower }}">{{ stack.requestMethod }}</span>
     </div>
-    <div class="label httplug-stack-header-target">
-        <span class="httplug-scheme">{{ stack.requestScheme }}://</span>
-        <span class="httplug-host">{{ stack.requestHost }}</span>
-        <span class="httplug-target">{{ stack.requestTarget }}</span>
-    </div>
+    {% spaceless %}
+        <div class="label httplug-stack-header-target">
+            <span class="httplug-scheme">{{ stack.requestScheme }}://</span>
+            <span class="httplug-host">{{ stack.requestHost }}</span>
+            <span class="httplug-target">{{ stack.requestTarget }}</span>
+        </div>
+    {% endspaceless %}
     <div>
         <span class="label httplug-duration">{{ stack.duration|number_format }} ms</span>
         {% if stack.responseCode >= 400 and stack.responseCode <= 599 %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

When URL from here 
<img width="1062" alt="image" src="https://user-images.githubusercontent.com/496233/135917237-e36be96f-d1d5-4d39-99ca-b1c816a55c14.png">

was copied, result of the clipboard was `http:// fe-client.ek.test /shopping_dev.php/category/7077?page_type=cgp&category_ids%5B0%5D=7077&deviceoutput=desktop&browser=firefox&browser_version=92&user_test_group=2`

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)
