### PR TITLE
Changed stopwatch category from default to "httplug"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# 1.23.2 - unreleased
+- Changed stopwatch category from default to "httplug", so it's more prominent on Execution timeline view
+
 # 1.23.1 - 2021-10-13
 - Fix issue with whitespaces in URL when URL in tab was copied
 - Fixed dark mode compatiblity, making some previously invisible elements visible

--- a/src/Collector/ProfileClient.php
+++ b/src/Collector/ProfileClient.php
@@ -52,6 +52,8 @@ class ProfileClient implements HttpClient, HttpAsyncClient
      */
     private $eventNames = [];
 
+    private const STOPWATCH_CATEGORY = 'httplug';
+
     /**
      * @param HttpClient|HttpAsyncClient $client The client to profile. Client must implement HttpClient or
      *                                           HttpAsyncClient interface.
@@ -85,7 +87,7 @@ class ProfileClient implements HttpClient, HttpAsyncClient
         }
 
         $this->collectRequestInformations($request, $stack);
-        $event = $this->stopwatch->start($this->getStopwatchEventName($request));
+        $event = $this->stopwatch->start($this->getStopwatchEventName($request), self::STOPWATCH_CATEGORY);
 
         $onFulfilled = function (ResponseInterface $response) use ($event, $stack) {
             $this->collectResponseInformations($response, $event, $stack);
@@ -128,7 +130,7 @@ class ProfileClient implements HttpClient, HttpAsyncClient
         }
 
         $this->collectRequestInformations($request, $stack);
-        $event = $this->stopwatch->start($this->getStopwatchEventName($request));
+        $event = $this->stopwatch->start($this->getStopwatchEventName($request), self::STOPWATCH_CATEGORY);
 
         try {
             $response = $this->client->sendRequest($request);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

I was irked that httplug queries in execution timeline section were grouped with other "default" stuff. It deserves it's own group so it's more prominent.

Maybe not the best example, as http queries here were quick, but you can still see some change

<table><tr><td>
<img width="890" alt="image" src="https://user-images.githubusercontent.com/496233/137401168-2d8db3f1-f11e-469d-8f4e-f808be0bb149.png">
</td><td><img width="827" alt="image" src="https://user-images.githubusercontent.com/496233/137401043-af33e111-77eb-4bb9-a806-8b2f4a6d40ed.png"></td></tr></table>