### PR TITLE
Changed default logging plugin monolog channel from "app" to "httplug"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 # 1.24.0 - unreleased
 - Changed stopwatch category from default to "httplug", so it's more prominent on Execution timeline view
 - Changed tab texts inside profiler so that it shows ports in URL in case it's non-standard
+- Changed default logging plugin monolog channel from "app" to "httplug"
 
 # 1.23.1 - 2021-10-13
 - Fixed issue with whitespaces in URL when URL in tab was copied

--- a/src/Resources/config/plugins.xml
+++ b/src/Resources/config/plugins.xml
@@ -21,6 +21,7 @@
         <service id="httplug.plugin.logger" class="Http\Client\Common\Plugin\LoggerPlugin" public="false" abstract="true">
             <argument />
             <argument>null</argument>
+            <tag name="monolog.logger" channel="httplug" />
         </service>
         <service id="httplug.plugin.redirect" class="Http\Client\Common\Plugin\RedirectPlugin" public="false" />
         <service id="httplug.plugin.retry" class="Http\Client\Common\Plugin\RetryPlugin" public="false" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | maybe, but unlikely
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT

It's pretty non-standard that bundles are using default "app" channel. It misleads users into thinking this is a log coming from application directly and breaks most of the channel filters which assume "app" channels are coming from application directly.