### PR TITLE
Fix PHP 8.1 deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# 1.24.1 - TBD
+- Fixed deprecation notice in PHP 8.1 by adding `= null` to `\Http\HttplugBundle\Collector\Twig\HttpMessageMarkupExtension` 
+- 
 # 1.24.0 - 2021-10-23
 - Changed stopwatch category from default to "httplug", so it's more prominent on Execution timeline view
 - Changed tab texts inside profiler so that it shows ports in URL in case it's non-standard

--- a/src/Collector/Twig/HttpMessageMarkupExtension.php
+++ b/src/Collector/Twig/HttpMessageMarkupExtension.php
@@ -26,7 +26,7 @@ class HttpMessageMarkupExtension extends AbstractExtension
      */
     private $dumper;
 
-    public function __construct(?ClonerInterface $cloner = null, ?DataDumperInterface $dumper)
+    public function __construct(?ClonerInterface $cloner = null, ?DataDumperInterface $dumper = null)
     {
         $this->cloner = $cloner ?: new VarCloner();
         $this->dumper = $dumper ?: new HtmlDumper();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|**yes**
| New feature?    | **no**|yes
| BC breaks?      | **no**|yes
| Deprecations?   | **no**|yes
| License         | MIT


#### What's in this PR?

Fixes this deprecation notice in PHP 8.1:

> Deprecated: Optional parameter $cloner declared before required parameter $dumper is implicitly treated as a required parameter in {project}/vendor/php-http/httplug-bundle/src/Collector/Twig/HttpMessageMarkupExtension.php on line 29

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)