### PR TITLE
Add PHP 8.1 to CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,11 +46,11 @@ jobs:
 
           # Latest commit to master
           - dependencies: "php-http/guzzle7-adapter php-http/vcr-plugin:^1.0@dev"
-            php-version: "8.0"
+            php-version: "8.1"
             stability: "dev"
             symfony-deprecations-helper: "weak"
           - dependencies: "php-http/guzzle7-adapter"
-            php-version: "8.0"
+            php-version: "8.1"
             stability: "dev"
             symfony-deprecations-helper: "weak"
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #407
| Documentation   | 
| License         | MIT


#### What's in this PR?

Adds PHP 8.1 to CI. Currently installs RC6.

#### Why?

So that we can verify that it works properly on PHP 8.1.
