### PR TITLE
allow to configure default_ttl to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# 1.26.0 - 2022-03-17
+
+- Fixed you can now configure the cache plugin default_ttl with `null`.
+
 # 1.25.0 - 2021-11-26
 - Added PHP 8.1 support
 - Added Symfony 6 support

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -713,8 +713,14 @@ class Configuration implements ConfigurationInterface
                 ->integerNode('cache_lifetime')
                     ->info('The minimum time we should store a cache item')
                 ->end()
-                ->integerNode('default_ttl')
+                ->scalarNode('default_ttl')
                     ->info('The default max age of a Response')
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            return null !== $v && !is_int($v);
+                        })
+                        ->thenInvalid('default_ttl must be an integer or null, got %s')
+                    ->end()
                 ->end()
                 ->arrayNode('blacklisted_paths')
                     ->info('An array of regular expression patterns for paths not to be cached. Defaults to an empty array.')

--- a/tests/Resources/Fixtures/config/ttl_null.yml
+++ b/tests/Resources/Fixtures/config/ttl_null.yml
@@ -1,0 +1,9 @@
+httplug:
+    clients:
+        test:
+            plugins:
+                -
+                    cache:
+                        cache_pool: my_custom_cache_pull
+                        config:
+                            default_ttl: null

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -453,4 +453,37 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $this->expectExceptionMessage('The child node "captured_body_length" at path "httplug.profiling" must be an integer or null');
         $this->assertProcessedConfigurationEquals([], [$file]);
     }
+
+    public function testNullDefaultTtl(): void
+    {
+        $file = __DIR__.'/../../Resources/Fixtures/config/ttl_null.yml';
+        $config = $this->emptyConfig;
+        $config['clients'] = [
+            'test' => [
+                'factory' => 'httplug.factory.auto',
+                'service' => null,
+                'public' => null,
+                'flexible_client' => false,
+                'http_methods_client' => false,
+                'batch_client' => false,
+                'config' => [],
+                'plugins' => [
+                    [
+                        'cache' => [
+                            'config' => [
+                                'default_ttl' => null,
+                                'blacklisted_paths' => [],
+                                'methods' => ['GET', 'HEAD'],
+                                'cache_listeners' => [],
+                            ],
+                            'cache_pool' => 'my_custom_cache_pull',
+                            'enabled' => true,
+                            'stream_factory' => 'httplug.stream_factory',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->assertProcessedConfigurationEquals($config, [$file]);
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes (allow configuring existing feature of cache plugin)
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #410
| Documentation   | -
| License         | MIT
