### PR TITLE
fix: prevent null respect_response_cache_directives

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -779,7 +779,7 @@ class Configuration implements ConfigurationInterface
                     ->info('A list of cache directives to respect when caching responses')
                     ->validate()
                         ->always(function ($v) {
-                            if (is_null($v) || is_array($v)) {
+                            if (is_array($v)) {
                                 return $v;
                             }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT

#### What's in this PR?

It prevents `respect_response_cache_directives` configuration key to be null, in order to prevent PHP error `array_intersect(): Argument #1 ($array) must be of type array, null given`

#### Why?

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/717869/164625204-22fa975a-3ed3-46ed-8526-a642cfe56962.png">

#### Example Usage

N/A

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
