### PR TITLE
correctly handle null value for respect_response_cache_directives 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# 1.26.1 - 2022-04-29
+
+- Fixed: Setting the cache plugin option `respect_response_cache_directives` to `null` makes the
+  plugin use the default set of directives instead of triggering an error.
+
 # 1.26.0 - 2022-03-17
 
 - Fixed you can now configure the cache plugin default_ttl with `null`.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -776,7 +776,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->variableNode('respect_response_cache_directives')
-                    ->info('A list of cache directives to respect when caching responses')
+                    ->info('A list of cache directives to respect when caching responses. Omit or set to null to respect the default set of directives.')
                     ->validate()
                         ->always(function ($v) {
                             if (is_null($v) || is_array($v)) {

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -198,6 +198,9 @@ class HttplugExtension extends Extension
         switch ($name) {
             case 'cache':
                 $options = $config['config'];
+                if (\array_key_exists('respect_response_cache_directives', $options) && null === $options['respect_response_cache_directives']) {
+                    unset($options['respect_response_cache_directives']);
+                }
                 if (!empty($options['cache_key_generator'])) {
                     $options['cache_key_generator'] = new Reference($options['cache_key_generator']);
                 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #415
| Documentation   | -
| License         | MIT

