### PR TITLE
cache_lifetime must be an integer or null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 # 1.xx.yy- YYYY-MM-JJ
 
-- Fixed you can now configure the cache plugin cache_lifetime with `null`.
+- Fixed: You can now configure the cache plugin option `cache_lifetime` to `null` (which makes the plugin not add to the maxAge).
 
 # 1.26.1 - 2022-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# 1.xx.yy- YYYY-MM-JJ
+
+- Fixed you can now configure the cache plugin cache_lifetime with `null`.
+
 # 1.26.1 - 2022-04-29
 
 - Fixed: Setting the cache plugin option `respect_response_cache_directives` to `null` makes the

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -725,7 +725,6 @@ class Configuration implements ConfigurationInterface
                             return null !== $v && !is_int($v);
                         })
                         ->thenInvalid('default_ttl must be an integer or null, got %s')
-                    ->end()
                 ->end()
                 ->arrayNode('blacklisted_paths')
                     ->info('An array of regular expression patterns for paths not to be cached. Defaults to an empty array.')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -710,9 +710,14 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('cache_key_generator')
                     ->info('This must be a service id to a service implementing '.CacheKeyGenerator::class)
                 ->end()
-                ->integerNode('cache_lifetime')
+                ->scalarNode('cache_lifetime')
                     ->info('The minimum time we should store a cache item')
-                ->end()
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            return null !== $v && !is_int($v);
+                        })
+                        ->thenInvalid('cache_lifetime must be an integer or null, got %s')
+                    ->end()
                 ->scalarNode('default_ttl')
                     ->info('The default max age of a Response')
                     ->validate()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -713,11 +713,12 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('cache_lifetime')
                     ->info('The minimum time we should store a cache item')
                     ->validate()
-                        ->ifTrue(function ($v) {
-                            return null !== $v && !is_int($v);
-                        })
-                        ->thenInvalid('cache_lifetime must be an integer or null, got %s')
+                    ->ifTrue(function ($v) {
+                        return null !== $v && !is_int($v);
+                    })
+                    ->thenInvalid('cache_lifetime must be an integer or null, got %s')
                     ->end()
+                ->end()
                 ->scalarNode('default_ttl')
                     ->info('The default max age of a Response')
                     ->validate()
@@ -725,6 +726,7 @@ class Configuration implements ConfigurationInterface
                             return null !== $v && !is_int($v);
                         })
                         ->thenInvalid('default_ttl must be an integer or null, got %s')
+                    ->end()
                 ->end()
                 ->arrayNode('blacklisted_paths')
                     ->info('An array of regular expression patterns for paths not to be cached. Defaults to an empty array.')


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Fix
Invalid type for path "httplug.clients.xxx.plugins.xxx.cache.config.cache_lifetime". Expected "int", but got "null".  

cache_lifetime must be an integer or null


#### Example Usage

``` yaml
cache_lifetime: ~
```


#### Checklist

- [x] Updated CHANGELOG.md to describe bugfix
