### PR TITLE
Make error plugin configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# 1.27.0 -
+
+- Added support for configuring options of error plugin via configuration
+
 # 1.26.2 - 2022-06-01
 
 - Fixed: You can now configure the cache plugin option `cache_lifetime` to `null` (which makes the plugin not add to the maxAge).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
-# 1.27.0 -
+# 1.27.0 - 2022-07-25
 
-- Added support for configuring options of error plugin via configuration
+- Added support for configuring the error plugin via configuration
 
 # 1.26.2 - 2022-06-01
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -590,6 +590,15 @@ class Configuration implements ConfigurationInterface
             ->end()
         ->end();
         // End stopwatch plugin
+
+        $error = $children->arrayNode('error')
+            ->canBeEnabled()
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('only_server_exception')->defaultFalse()->end()
+            ->end()
+        ->end();
+        // End error plugin
     }
 
     /**

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -275,6 +275,13 @@ class HttplugExtension extends Extension
 
                 break;
 
+            case 'error':
+                $definition->addArgument([
+                    'only_server_exception' => $config['only_server_exception'],
+                ]);
+
+                break;
+
             /* client specific plugins */
 
             case 'add_host':

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -94,6 +94,10 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'enabled' => true,
                 'stopwatch' => 'debug.stopwatch',
             ],
+            'error' => [
+                'enabled' => false,
+                'only_server_exception' => false,
+            ],
         ],
         'discovery' => [
             'client' => 'auto',
@@ -293,6 +297,10 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'stopwatch' => [
                     'enabled' => false,
                     'stopwatch' => 'debug.stopwatch',
+                ],
+                'error' => [
+                    'enabled' => false,
+                    'only_server_exception' => false,
                 ],
             ],
             'discovery' => [

--- a/tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -139,6 +139,11 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
                                 'cache_pool' => 'my_cache_pool',
                             ],
                         ],
+                        [
+                            'error' => [
+                                'only_server_exception' => true,
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -156,6 +161,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
             'httplug.client.acme.plugin.query_defaults',
             'httplug.client.acme.authentication.my_basic',
             'httplug.client.acme.plugin.cache',
+            'httplug.client.acme.plugin.error',
         ];
         $pluginReferences = array_map(function ($id) {
             return new Reference($id);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | https://github.com/php-http/documentation/pull/297
| License         | MIT


#### What's in this PR?

Makes the error plugin configurable in HttplugBundle.


#### Why?

As far as I can tell, enabling the ErrorPlugin via  configuration is currently not easily possible. For applications it can make sense to violate the PSR-18 spec and have this configuration enabled, so adding it to the bundle seems reasonable to me.


#### Example Usage

``` yaml
# config/packages/httplug.yaml
httplug:
    clients:
        my_client:
            factory: 'httplug.factory.guzzle7'
            config:
                connect_timeout: 1
                timeout: 10
                force_ip_resolve: 'v4'
            plugins:
                - error: ~
```


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)


#### To Do

- [x] Fix failing tests, if it is confirmed this change makes sense
