### PR TITLE
tell user if body capturing was disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# unreleased
+
+- If captured_body_length is set to 0 (default value), show a special message rather than the
+  generic message `This message has no captured body`.
+
 # 1.27.0 - 2022-07-25
 
 - Added support for configuring the error plugin via configuration

--- a/src/Collector/Collector.php
+++ b/src/Collector/Collector.php
@@ -9,8 +9,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 
 /**
- * The Collector hold profiled Stacks pushed by StackPlugin. It also have a list of configured clients.
- * All those data are used to display the HTTPlug panel in the Symfony profiler.
+ * The Collector holds profiled Stacks pushed by the StackPlugin. It also has a list of the configured clients.
+ * This data is used to display the HTTPlug panel in the Symfony profiler.
  *
  * The collector is not designed for execution in a threaded application and does not support plugins that execute an
  * other request before the current one is sent by the client.
@@ -26,9 +26,15 @@ class Collector extends DataCollector
      */
     private $activeStack;
 
-    public function __construct()
+    /**
+     * @var int|null
+     */
+    private $capturedBodyLength;
+
+    public function __construct(?int $capturedBodyLength = null)
     {
         $this->reset();
+        $this->capturedBodyLength = $capturedBodyLength;
     }
 
     /**
@@ -46,6 +52,11 @@ class Collector extends DataCollector
     public function getName(): string
     {
         return 'httplug';
+    }
+
+    public function getCapturedBodyLength(): ?int
+    {
+        return $this->capturedBodyLength;
     }
 
     /**

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -94,6 +94,10 @@ class HttplugExtension extends Extension
                 ->getDefinition('httplug.formatter.full_http_message')
                 ->addArgument($config['profiling']['captured_body_length'])
             ;
+            $container
+                ->getDefinition('httplug.collector.collector')
+                ->addArgument($config['profiling']['captured_body_length'])
+            ;
 
             if (!class_exists(TwigEnvironment::class) && !class_exists(\Twig_Environment::class)) {
                 $container->removeDefinition('httplug.collector.twig.http_message');

--- a/src/Resources/views/http_message.html.twig
+++ b/src/Resources/views/http_message.html.twig
@@ -2,7 +2,7 @@
 {% set content = '' %}
 {% set data = data|split("\n")|slice(1) %}
 {% set xdebugTokenLink = data|filter(v => 'x-debug-token-link:' in v|lower)|first|split(': ')|last %}
-
+{% set noContent = 0 is same as capturedBodyLength ? '(captured_body_length is set to 0, no body captured)' : '(This message has no captured body)' %}
 <table>
     <thead>
     <tr>
@@ -33,4 +33,4 @@
     </tbody>
 </table>
 
-<div class='httplug-http-body httplug-hidden'>{{ content ? content|httplug_markup_body : '(This message has no captured body)' }}</div>
+<div class='httplug-http-body httplug-hidden'>{{ content ? content|httplug_markup_body : noContent }}</div>

--- a/src/Resources/views/http_message.html.twig
+++ b/src/Resources/views/http_message.html.twig
@@ -2,7 +2,7 @@
 {% set content = '' %}
 {% set data = data|split("\n")|slice(1) %}
 {% set xdebugTokenLink = data|filter(v => 'x-debug-token-link:' in v|lower)|first|split(': ')|last %}
-{% set noContent = 0 is same as capturedBodyLength ? '(captured_body_length is set to 0, no body captured)' : '(This message has no captured body)' %}
+{% set noContent = capturedBodyLength is same as(0) ? '(captured_body_length is set to 0, no body captured)' : '(This message has no captured body)' %}
 <table>
     <thead>
     <tr>

--- a/src/Resources/views/stack.html.twig
+++ b/src/Resources/views/stack.html.twig
@@ -39,10 +39,10 @@
     </div>
     <div class="httplug-messages">
         <div class="httplug-message card">
-            {{ include('@Httplug/http_message.html.twig', { data: stack.clientRequest, header: 'Request' }, with_context=false) }}
+            {{ include('@Httplug/http_message.html.twig', { data: stack.clientRequest, capturedBodyLength: collector.capturedBodyLength, header: 'Request' }, with_context=false) }}
         </div>
         <div class="httplug-message card">
-            {{ include('@Httplug/http_message.html.twig', { data: stack.clientResponse, header: 'Response' }, with_context=false) }}
+            {{ include('@Httplug/http_message.html.twig', { data: stack.clientResponse, capturedBodyLength: collector.capturedBodyLength, header: 'Response' }, with_context=false) }}
         </div>
     </div>
     {% if stack.profiles %}
@@ -51,10 +51,10 @@
                 <h3 class="httplug-plugin-name">{{ profile.plugin }}</h3>
                 <div class="httplug-messages">
                     <div class="httplug-message">
-                        {{ include('@Httplug/http_message.html.twig', { data: profile.request, header: 'Request' }, with_context=false) }}
+                        {{ include('@Httplug/http_message.html.twig', { data: profile.request, capturedBodyLength: collector.capturedBodyLength, header: 'Request' }, with_context=false) }}
                     </div>
                     <div class="httplug-message">
-                        {{ include('@Httplug/http_message.html.twig', { data: profile.response, header: 'Response' }, with_context=false) }}
+                        {{ include('@Httplug/http_message.html.twig', { data: profile.response, capturedBodyLength: collector.capturedBodyLength, header: 'Response' }, with_context=false) }}
                     </div>
                 </div>
                 {% if not loop.last %}

--- a/tests/Functional/ProfilingTest.php
+++ b/tests/Functional/ProfilingTest.php
@@ -41,7 +41,7 @@ class ProfilingTest extends TestCase
 
     public function setUp(): void
     {
-        $this->collector = new Collector([]);
+        $this->collector = new Collector();
         $this->formatter = new Formatter(new FullHttpMessageFormatter(), new CurlCommandFormatter());
         $this->stopwatch = new Stopwatch();
     }

--- a/tests/Resources/app/config/config_test.yml
+++ b/tests/Resources/app/config/config_test.yml
@@ -1,6 +1,7 @@
 framework:
   secret: php-http
   test: ~
+  http_method_override: false
 
 httplug:
     discovery:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes, DX fix
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #420
| Documentation   | -
| License         | MIT


#### What's in this PR?

Report when the captured_body_length is configured 0 (the default value). This is better than we currently just saying that there is no captured body.


#### Why?

Improve DX. See #420

