### PR TITLE
Profiler: Add slash if there is none between host and path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 - If captured_body_length is set to 0 (default value), show a special message rather than the
   generic message `This message has no captured body`.
+- Fixed: Add slash in profiler if there is none between host and path
 
 # 1.27.0 - 2022-07-25
 

--- a/src/Resources/views/stack.html.twig
+++ b/src/Resources/views/stack.html.twig
@@ -14,7 +14,7 @@
             {% if stack.requestPort not in [null, 80, 443] %}
                 <span class="httplug-port">:{{ stack.requestPort }}</span>
             {% endif %}
-            <span class="httplug-target">{{ stack.requestTarget }}</span>
+            <span class="httplug-target">{{ (stack.requestTarget|default('/') starts with '/' ? '' : '/')  ~ stack.requestTarget }}</span>
         </div>
     {% endapply %}
     <div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

See 
![image](https://user-images.githubusercontent.com/496233/190633752-cc602c4c-d00c-4b0d-bae6-242a3f2ac77d.png)
![image](https://user-images.githubusercontent.com/496233/190633760-f2bd954a-e946-4e4c-8110-c1da55036a2d.png)

Looks like in case target doesn't have leading slash, profiler shows strange URL