### PR TITLE
Add `void` return type to `ResetInterface::reset()`

### DIFF
--- a/src/Collector/Collector.php
+++ b/src/Collector/Collector.php
@@ -40,7 +40,7 @@ class Collector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function reset()
+    public function reset(): void
     {
         $this->data['stacks'] = [];
         $this->activeStack = null;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes ??
| Deprecations?   | no
| Related tickets |
| Documentation   | 
| License         | MIT


```
Method "Symfony\Contracts\Service\ResetInterface::reset()" might add "void" as a native return type declaration in the future. Do the same in implementation "Http\HttplugBundle\Collector\Collector" now to avoid errors or add an explicit @return annotation to suppress this message.
```