### PR TITLE
use semantic branch naming

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,7 +3,9 @@ name: "CI"
 on:
   push:
     branches:
-      - master
+      - '[0-9]+.x'
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.x'
   pull_request:
 
 jobs:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,7 +3,9 @@ name: "Static analysis"
 on:
   push:
     branches:
-      - master
+      - '[0-9]+.x'
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.x'
   pull_request:
 
 jobs:

--- a/composer.json
+++ b/composer.json
@@ -76,11 +76,6 @@
             "symfony/flex": true
         }
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.x-dev"
-        }
-    },
     "autoload": {
         "psr-4": {
             "Http\\HttplugBundle\\": "src/"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Switched to use semantic branch naming instead of generic `master`


#### Why?

Get rid of branch-alias and simplify live when we start a version 2, 3 etc.