### PR TITLE
Deprecated HttpClient service, added ClientInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# unreleased
+
+- Marked `Http\Client\HttpClient` service as deprecated (#425).
+- Added `Psr\Http\Client\ClientInterface` service (#425).
+
 # 1.27.1 - 2023-03-03
 
 - Added `: void` to `Collector::reset` to avoid PHP warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 # unreleased
 
-- Marked `Http\Client\HttpClient` service as deprecated (#425).
+- Deprecated `Http\Client\HttpClient` in favor of `Psr\Http\Client\ClientInterface` (#425).
 - Added `Psr\Http\Client\ClientInterface` service (#425).
 
 # 1.27.1 - 2023-03-03

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -48,7 +48,7 @@
             <factory class="Http\Discovery\HttpClientDiscovery" method="find" />
         </service>
         <service id="Http\Client\HttpClient" alias="httplug.client" public="false">
-            <deprecated />
+            <deprecated version="1.28" />
         </service>
         <service id="Psr\Http\Client\ClientInterface" alias="httplug.client" public="false" />
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -48,7 +48,7 @@
             <factory class="Http\Discovery\HttpClientDiscovery" method="find" />
         </service>
         <service id="Http\Client\HttpClient" alias="httplug.client" public="false">
-            <deprecated version="1.28" />
+            <deprecated package="php-http/httplug-bundle" version="1.28" message="deprecated in favor of PSR-7 ClientInterface" />
         </service>
         <service id="Psr\Http\Client\ClientInterface" alias="httplug.client" public="false" />
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -48,7 +48,7 @@
             <factory class="Http\Discovery\HttpClientDiscovery" method="find" />
         </service>
         <service id="Http\Client\HttpClient" alias="httplug.client" public="false">
-            <deprecated package="php-http/httplug-bundle" version="1.28" message="deprecated in favor of PSR-7 ClientInterface" />
+            <deprecated package="php-http/httplug-bundle" version="1.28" />
         </service>
         <service id="Psr\Http\Client\ClientInterface" alias="httplug.client" public="false" />
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -47,7 +47,10 @@
         <service id="httplug.client.default" class="Http\Client\HttpClient">
             <factory class="Http\Discovery\HttpClientDiscovery" method="find" />
         </service>
-        <service id="Http\Client\HttpClient" alias="httplug.client" public="false" />
+        <service id="Http\Client\HttpClient" alias="httplug.client" public="false">
+            <deprecated />
+        </service>
+        <service id="Psr\Http\Client\ClientInterface" alias="httplug.client" public="false" />
 
         <!-- Discovery for PSR-18 -->
         <service id="httplug.psr18_client.default" class="Psr\Http\Client\ClientInterface">


### PR DESCRIPTION
Fixes #425

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | fixes #425 
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

It deprecates exposing the deprecated `Http\Client\HttpClient` and adds default service `Psr\Http\Client\ClientInterface`.


#### Why?




#### Example Usage



#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
