### PR TITLE
autowire PSR-18 ClientInterface, deprecate httplug Client autowire service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+# unreleased
+
+- Deprecated `Http\Client\HttpClient` in favor of `Psr\Http\Client\ClientInterface` (#425).
+- Added alias to autowire `Psr\Http\Client\ClientInterface` service (#425).
+
 # 1.27.1 - 2023-03-03
 
 - Added `: void` to `Collector::reset` to avoid PHP warning.

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -32,6 +32,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\Kernel;
 use Twig\Environment as TwigEnvironment;
 
 /**
@@ -60,6 +61,12 @@ class HttplugExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load('services.xml');
+        // TODO: Move this back into services.xml when we drop support for Symfony 4, or completely remove the service in the next major version.
+        if (Kernel::MAJOR_VERSION >= 5) {
+            $loader->load('services_legacy.xml');
+        } else {
+            $loader->load('services_legacy_sf4.xml');
+        }
         $loader->load('plugins.xml');
         if (\class_exists(MockClient::class)) {
             $loader->load('mock-client.xml');

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -47,7 +47,7 @@
         <service id="httplug.client.default" class="Http\Client\HttpClient">
             <factory class="Http\Discovery\HttpClientDiscovery" method="find" />
         </service>
-        <service id="Http\Client\HttpClient" alias="httplug.client" public="false" />
+        <service id="Psr\Http\Client\ClientInterface" alias="httplug.client" public="false" />
 
         <!-- Discovery for PSR-18 -->
         <service id="httplug.psr18_client.default" class="Psr\Http\Client\ClientInterface">

--- a/src/Resources/config/services_legacy.xml
+++ b/src/Resources/config/services_legacy.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Http\Client\HttpClient" alias="httplug.client" public="false">
+            <deprecated package="php-http/httplug-bundle" version="1.28">The "%alias_id%" service is deprecated in favor of using PSR-7 Psr\Http\Client\ClientInterface</deprecated>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/services_legacy_sf4.xml
+++ b/src/Resources/config/services_legacy_sf4.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Http\Client\HttpClient" alias="httplug.client" public="false">
+            <deprecated>The "%alias_id%" service is deprecated in favor of using PSR-7 Psr\Http\Client\ClientInterface</deprecated>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | fixes #425, fixes #426
| Documentation   | -
| License         | MIT


#### What's in this PR?

It deprecates exposing the deprecated Http\Client\HttpClient and adds default service Psr\Http\Client\ClientInterface.

#### Why?

The httplug interface is deprecated in favor of the PSR client.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
