### PR TITLE
Use ClientInterface in MockFactory

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,10 +44,6 @@ jobs:
             php-version: "8.2"
             symfony-deprecations-helper: "weak"
 
-          # Test with httplug 1.x clients
-          - dependencies: "php-http/buzz-adapter:^1.0 php-http/guzzle6-adapter:^1.1.1 php-http/react-adapter:^0.2.1"
-            php-version: "7.3"
-            symfony-deprecations-helper: "weak"
           # Test with httplug 2.x clients
           - dependencies: "php-http/guzzle7-adapter php-http/curl-client:^2.0.0 php-http/vcr-plugin:^1.0@dev php-http/socket-client:^2.0"
             php-version: "7.3"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php-http/client-common": "^1.9 || ^2.0",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.14",
-        "php-http/httplug": "^1.0 || ^2.0",
+        "php-http/httplug": "^2.0",
         "php-http/logger-plugin": "^1.1",
         "php-http/message": "^1.4",
         "php-http/message-factory": "^1.0.2",

--- a/src/ClientFactory/MockFactory.php
+++ b/src/ClientFactory/MockFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Http\HttplugBundle\ClientFactory;
 
-use Http\Client\HttpClient;
 use Http\Mock\Client;
+use Psr\Http\Client\ClientInterface;
 
 /**
  * @author Gary PEGEOT <garypegeot@gmail.com>
@@ -13,7 +13,7 @@ use Http\Mock\Client;
 final class MockFactory implements ClientFactory
 {
     /**
-     * @var HttpClient
+     * @var ClientInterface
      */
     private $client;
 
@@ -22,7 +22,7 @@ final class MockFactory implements ClientFactory
      *
      * Note that this can be any client, not only a mock client.
      */
-    public function setClient(HttpClient $client)
+    public function setClient(ClientInterface $client)
     {
         $this->client = $client;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | ?
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

HttpClient is deprecated in favor of ClientInterface. By accepting ClientInterface in the MockFactory, developers can transition to the ClientInterface.
