### PR TITLE
Add `void` return type to `collect()` method

### DIFF
--- a/src/Collector/Collector.php
+++ b/src/Collector/Collector.php
@@ -195,7 +195,7 @@ class Collector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, $exception = null)
+    public function collect(Request $request, Response $response, $exception = null): void
     {
         // We do not need to collect any data from the Symfony Request and Response
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   |
| License         | MIT


#### What's in this PR?

Needed for Symfony 6.3.

```
 1x: Method "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::collect()" might add "void" as a native return type declaration in the future. Do the same in implementation "Http\HttplugBundle\Collector\Collector" now to avoid errors or add an explicit @return annotation to suppress this message.
```