### PR TITLE
chore: Add ClientInterface return typehint for php-http/httplug >= 2.4

### DIFF
--- a/src/ClientFactory/ClientFactory.php
+++ b/src/ClientFactory/ClientFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Http\HttplugBundle\ClientFactory;
 
 use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -14,7 +15,7 @@ interface ClientFactory
     /**
      * Input an array of configuration to be able to create a HttpClient.
      *
-     * @return HttpClient
+     * @return HttpClient|ClientInterface
      */
     public function createClient(array $config = []);
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Deprecations?   | yes


#### What's in this PR?

Add ClientInterface return typehint for php-http/httplug >= 2.4


#### Why?

Return type of method ClientFactory::createClient() has typehint with deprecated interface Http\Client\HttpClient: 
since version 2.4, use Psr\Http\Client\ClientInterface instead
