### PR TITLE
Register HttpAsyncClient as alias

### DIFF
--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -408,6 +408,7 @@ class HttplugExtension extends Extension
 
         $container->registerAliasForArgument($serviceId, HttpClient::class, $clientName);
         $container->registerAliasForArgument($serviceId, ClientInterface::class, $clientName);
+        $container->registerAliasForArgument($serviceId, HttpAsyncClient::class, $clientName);
 
         $plugins = [];
         foreach ($arguments['plugins'] as $plugin) {


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   |
| License         | MIT


#### What's in this PR?

This allows type hinting against `HttpAsyncClient`.


