### PR TITLE
feat: header authentication service configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+- Added configuration for the `header` authentication plugin (#437).
+
 # 1.30.1 - 2023-09-07
 
 - Added alias to allow autowiring the `AsyncHttpClient` interface (#436).

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php-http/discovery": "^1.14",
         "php-http/httplug": "^2.0",
         "php-http/logger-plugin": "^1.1",
-        "php-http/message": "^1.4",
+        "php-http/message": "^1.9",
         "php-http/message-factory": "^1.0.2",
         "php-http/stopwatch-plugin": "^1.2",
         "psr/http-message": "^1.0 || ^2.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -663,6 +663,10 @@ class Configuration implements ConfigurationInterface
                                 $this->validateAuthenticationType(['params'], $config, 'query_param');
 
                                 break;
+                            case 'header':
+                                $this->validateAuthenticationType(['header_name', 'header_value'], $config, 'header');
+
+                                break;
                         }
 
                         return $config;
@@ -670,7 +674,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->children()
                     ->enumNode('type')
-                        ->values(['basic', 'bearer', 'wsse', 'service', 'query_param'])
+                        ->values(['basic', 'bearer', 'wsse', 'service', 'query_param', 'header'])
                         ->isRequired()
                         ->cannotBeEmpty()
                     ->end()
@@ -678,6 +682,8 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('password')->end()
                     ->scalarNode('token')->end()
                     ->scalarNode('service')->end()
+                    ->scalarNode('header_name')->end()
+                    ->scalarNode('header_value')->end()
                     ->arrayNode('params')->prototype('scalar')->end()
                     ->end()
                 ->end()

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -18,6 +18,7 @@ use Http\Client\Plugin\Vcr\RecordPlugin;
 use Http\Client\Plugin\Vcr\ReplayPlugin;
 use Http\Message\Authentication\BasicAuth;
 use Http\Message\Authentication\Bearer;
+use Http\Message\Authentication\Header;
 use Http\Message\Authentication\QueryParam;
 use Http\Message\Authentication\Wsse;
 use Http\Mock\Client as MockClient;
@@ -379,6 +380,12 @@ class HttplugExtension extends Extension
                 case 'query_param':
                     $container->register($authServiceKey, QueryParam::class)
                         ->addArgument($values['params']);
+
+                    break;
+                case 'header':
+                    $container->register($authServiceKey, Header::class)
+                        ->addArgument($values['header_name'])
+                        ->addArgument($values['header_value']);
 
                     break;
                 case 'service':

--- a/tests/Resources/Fixtures/config/full.php
+++ b/tests/Resources/Fixtures/config/full.php
@@ -96,6 +96,11 @@ $container->loadFromExtension('httplug', [
                 'type' => 'bearer',
                 'token' => 'foo',
             ],
+            'my_header' => [
+                'type' => 'header',
+                'header_name' => 'foo',
+                'header_value' => 'bar',
+            ],
             'my_service' => [
                 'type' => 'service',
                 'service' => 'my_auth_service',

--- a/tests/Resources/Fixtures/config/full.xml
+++ b/tests/Resources/Fixtures/config/full.xml
@@ -58,6 +58,7 @@
                 <my_basic type="basic" username="foo" password="bar"/>
                 <my_wsse type="wsse" username="foo" password="bar"/>
                 <my_bearer type="bearer" token="foo"/>
+                <my_header type="header" header_name="foo" header_value="bar" />
                 <my_service type="service" service="my_auth_service"/>
             </authentication>
             <cache cache-pool="my_cache_pool" stream-factory="my_other_stream_factory">

--- a/tests/Resources/Fixtures/config/full.yml
+++ b/tests/Resources/Fixtures/config/full.yml
@@ -65,6 +65,10 @@ httplug:
             my_bearer:
                 type: bearer
                 token: foo
+            my_header:
+                type: header
+                header_name: foo
+                header_value: bar
             my_service:
                 type: service
                 service: my_auth_service

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -244,6 +244,12 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                         'token' => 'foo',
                         'params' => [],
                     ],
+                    'my_header' => [
+                        'type' => 'header',
+                        'header_name' => 'foo',
+                        'header_value' => 'bar',
+                        'params' => [],
+                    ],
                     'my_service' => [
                         'type' => 'service',
                         'service' => 'my_auth_service',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #437 
| Documentation   | https://github.com/php-http/documentation/pull/313
| License         | MIT


#### What's in this PR?

Exposes configuration for the header authentication plugin.

#### Why?

Allows the direct usage of this plugin through the bundle configuration.

#### Example Usage

``` yaml
  - authentication:
      header:
          type: header
          key: "ApiKey"
          value: "%env(SAMPLE_API_TOKEN)%"
```


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)


#### To Do

N/A