### PR TITLE
Drop support for Symfony versions <5.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,13 +60,13 @@ jobs:
             symfony-deprecations-helper: "weak"
 
           # Test maintained versions of Symfony
-          - dependencies: "php-http/guzzle7-adapter symfony/http-client:^4.4"
-            symfony-require: "4.4.*"
-            php-version: "7.3"
-            symfony-deprecations-helper: "weak"
-          - dependencies: "php-http/guzzle7-adapter symfony/http-client:^5.0"
+          - dependencies: "php-http/guzzle7-adapter symfony/http-client:^5.4"
             symfony-require: "5.4.*"
             php-version: "7.3"
+            symfony-deprecations-helper: "weak"
+          - dependencies: "php-http/guzzle7-adapter symfony/http-client:^6.0"
+            symfony-require: "6.3.*"
+            php-version: "8.2"
             symfony-deprecations-helper: "weak"
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 - Removed support of deprecated PHP-HTTP factories, only PSR-17 factories are now supported and used.
 - Removed `message_factory`, `uri_factory`, and `stream_factory` classes config option. You can configure your own factories via psr17_*_factory classes config
 - Removed support for guzzle5-adapter
+- Removed support for Symfony versions <5.4
 
 # Version 1
 

--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,11 @@
         "php-http/stopwatch-plugin": "^1.2",
         "psr/http-factory-implementation": "^1.0",
         "psr/http-message": "^1.0 || ^2.0",
-        "symfony/config": "^4.4 || ^5.0 || ^6.0",
-        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
-        "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0",
-        "symfony/options-resolver": "^4.4 || ^5.0 || ^6.0"
+        "symfony/config": "^5.4 || ^6.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0",
+        "symfony/event-dispatcher": "^5.4 || ^6.0",
+        "symfony/http-kernel": "^5.4 || ^6.0",
+        "symfony/options-resolver": "^5.4 || ^6.0"
     },
     "conflict": {
         "php-http/guzzle6-adapter": "<1.1",
@@ -57,15 +57,15 @@
         "php-http/cache-plugin": "^1.7",
         "php-http/mock-client": "^1.2",
         "php-http/promise": "^1.0",
-        "symfony/browser-kit": "^4.4 || ^5.0 || ^6.0",
-        "symfony/cache": "^4.4 || ^5.0 || ^6.0",
-        "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
-        "symfony/http-foundation": "^4.4.19 || ^5.0 || ^6.0",
-        "symfony/phpunit-bridge": "^5.3",
-        "symfony/stopwatch": "^4.4 || ^5.0 || ^6.0",
-        "symfony/twig-bundle": "^4.4 || ^5.0 || ^6.0",
-        "symfony/web-profiler-bundle": "^4.4.19 || ^5.0 || ^6.0",
+        "symfony/browser-kit": "^5.4 || ^6.0",
+        "symfony/cache": "^5.4 || ^6.0",
+        "symfony/dom-crawler": "^5.4 || ^6.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0",
+        "symfony/http-foundation": "^5.4 || ^6.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.0",
+        "symfony/stopwatch": "^5.4 || ^6.0",
+        "symfony/twig-bundle": "^5.4 || ^6.0",
+        "symfony/web-profiler-bundle": "^5.4 || ^6.0",
         "twig/twig": "^1.41 || ^2.10 || ^3.0"
     },
     "suggest": {
@@ -76,7 +76,8 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "symfony/flex": true
+            "symfony/flex": true,
+            "php-http/discovery": false
         }
     },
     "autoload": {

--- a/src/Collector/PluginClientFactoryListener.php
+++ b/src/Collector/PluginClientFactoryListener.php
@@ -5,16 +5,8 @@ declare(strict_types=1);
 namespace Http\HttplugBundle\Collector;
 
 use Http\Client\Common\PluginClientFactory as DefaultPluginClientFactory;
-use Symfony\Component\EventDispatcher\Event as LegacyEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Contracts\EventDispatcher\Event;
-
-if (Kernel::MAJOR_VERSION >= 5) {
-    \class_alias(Event::class, 'Http\HttplugBundle\Collector\PluginClientFactoryListenerEventClass');
-} else {
-    \class_alias(LegacyEvent::class, 'Http\HttplugBundle\Collector\PluginClientFactoryListenerEventClass');
-}
 
 /**
  * This subscriber ensures that every PluginClient created when using Http\Client\Common\PluginClientFactory without
@@ -40,7 +32,7 @@ final class PluginClientFactoryListener implements EventSubscriberInterface
     /**
      * Make sure to profile clients created using PluginClientFactory.
      */
-    public function onEvent(PluginClientFactoryListenerEventClass $e)
+    public function onEvent(Event $e)
     {
         DefaultPluginClientFactory::setFactory([$this->factory, 'createClient']);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | addresses a part of https://github.com/php-http/HttplugBundle/pull/439#issuecomment-1820427669
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

Drops support for Symfony version <5.4


#### Why?

Symfony 4.4 only receives security updates. Current LTS is 5.4 and will soon be 6.4.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] I think I got everything but in case I missed something let me know
