### PR TITLE
support cache plugin 2.x, bump to minimum 1.7 to always support psr17…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     },
     "conflict": {
         "php-http/guzzle6-adapter": "<1.1",
+        "php-http/cache-plugin": "<1.7.0",
         "php-http/curl-client": "<2.0",
         "php-http/socket-client": "<2.0"
     },

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,8 +13,8 @@ use Http\Client\Plugin\Vcr\Recorder\PlayerInterface;
 use Http\Client\Plugin\Vcr\Recorder\RecorderInterface;
 use Http\Message\CookieJar;
 use Http\Message\Formatter;
-use Http\Message\StreamFactory;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
@@ -744,7 +744,7 @@ class Configuration implements ConfigurationInterface
                     // Cannot set both respect_cache_headers and respect_response_cache_directives
                     return isset($config['respect_cache_headers'], $config['respect_response_cache_directives']);
                 })
-                ->thenInvalid('You can\'t provide config option "respect_cache_headers" and "respect_response_cache_directives" simultaniously. Use "respect_response_cache_directives" instead.')
+                ->thenInvalid('You can\'t provide config option "respect_cache_headers" and "respect_response_cache_directives" simultaneously. Use "respect_response_cache_directives" instead.')
             ->end()
             ->children()
                 ->scalarNode('cache_key_generator')
@@ -856,8 +856,8 @@ class Configuration implements ConfigurationInterface
                     ->cannotBeEmpty()
                 ->end()
                 ->scalarNode('stream_factory')
-                    ->info('This must be a service id to a service implementing '.StreamFactory::class)
-                    ->defaultValue('httplug.stream_factory')
+                    ->info('This must be a service id to a service implementing '.StreamFactoryInterface::class)
+                    ->defaultValue('httplug.psr17_stream_factory')
                     ->cannotBeEmpty()
                 ->end()
             ->end()

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -59,7 +59,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             'authentication' => [],
             'cache' => [
                 'enabled' => false,
-                'stream_factory' => 'httplug.stream_factory',
+                'stream_factory' => 'httplug.psr17_stream_factory',
                 'config' => [
                     'methods' => ['GET', 'HEAD'],
                     'blacklisted_paths' => [],
@@ -363,7 +363,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $file = __DIR__.'/../../Resources/Fixtures/config/invalid_cache_config.yml';
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Invalid configuration for path "httplug.plugins.cache.config": You can\'t provide config option "respect_cache_headers" and "respect_response_cache_directives" simultaniously. Use "respect_response_cache_directives" instead.');
+        $this->expectExceptionMessage('Invalid configuration for path "httplug.plugins.cache.config": You can\'t provide config option "respect_cache_headers" and "respect_response_cache_directives" simultaneously. Use "respect_response_cache_directives" instead.');
         $this->assertProcessedConfigurationEquals([], [$file]);
     }
 
@@ -492,7 +492,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                             ],
                             'cache_pool' => 'my_custom_cache_pull',
                             'enabled' => true,
-                            'stream_factory' => 'httplug.stream_factory',
+                            'stream_factory' => 'httplug.psr17_stream_factory',
                         ],
                     ],
                 ],


### PR DESCRIPTION
… stream factory

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes [#160](https://github.com/php-http/message/issues/160)
| Documentation   | -
| License         | MIT


#### What's in this PR?

Set up cache plugin with psr17 stream factory to be compatible with cache plugin 2.x. Set minimum version to 1.7 because that is the first version that accets the psr17 factory.