### PR TITLE
feat: add factory for NoPrivateNetworkHttpClient

### DIFF
--- a/src/ClientFactory/SymfonyNoPrivateNetworkFactory.php
+++ b/src/ClientFactory/SymfonyNoPrivateNetworkFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Http\HttplugBundle\ClientFactory;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\HttplugClient;
+use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;
+
+class SymfonyNoPrivateNetworkFactory
+{
+    /**
+     * @var ResponseFactoryInterface
+     */
+    private $responseFactory;
+
+    /**
+     * @var StreamFactoryInterface
+     */
+    private $streamFactory;
+
+    public function __construct(ResponseFactoryInterface $responseFactory, StreamFactoryInterface $streamFactory)
+    {
+        $this->responseFactory = $responseFactory;
+        $this->streamFactory = $streamFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createClient(array $config = [])
+    {
+        if (!class_exists(HttplugClient::class)) {
+            throw new \LogicException('To use the Symfony client you need to install the "symfony/http-client" package.');
+        }
+
+        if (!class_exists(NoPrivateNetworkHttpClient::class)) {
+            throw new \LogicException('To use the No Private Network client you need to install the "symfony/http-client" version 5.1 or greater.');
+        }
+
+        return new HttplugClient(new NoPrivateNetworkHttpClient(HttpClient::create($config)), $this->responseFactory, $this->streamFactory);
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -101,5 +101,9 @@
             <argument type="service" id="httplug.psr17_response_factory"/>
             <argument type="service" id="httplug.psr17_stream_factory"/>
         </service>
+        <service id="httplug.factory.symfony_no_private_network" class="Http\HttplugBundle\ClientFactory\SymfonyNoPrivateNetworkFactory" public="false">
+            <argument type="service" id="httplug.psr17_response_factory"/>
+            <argument type="service" id="httplug.psr17_stream_factory"/>
+        </service>
     </services>
 </container>

--- a/tests/Unit/ClientFactory/SymfonyNoPrivateNetworkFactoryTest.php
+++ b/tests/Unit/ClientFactory/SymfonyNoPrivateNetworkFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\HttplugBundle\Tests\Unit\ClientFactory;
+
+use Http\HttplugBundle\ClientFactory\SymfonyFactory;
+use Http\HttplugBundle\ClientFactory\SymfonyNoPrivateNetworkFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Symfony\Component\HttpClient\HttplugClient;
+use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class SymfonyNoPrivateNetworkFactoryTest extends TestCase
+{
+    public function testCreateClient(): void
+    {
+        if (!class_exists(HttplugClient::class)) {
+            $this->markTestSkipped('Symfony Http client is not installed');
+        }
+
+        if (!class_exists(NoPrivateNetworkHttpClient::class)) {
+            $this->markTestSkipped('No Private Network http client is available in this Symfony version.');
+        }
+
+        $factory = new SymfonyNoPrivateNetworkFactory(
+            $this->createMock(ResponseFactoryInterface::class),
+            $this->createMock(StreamFactoryInterface::class)
+        );
+        $client = $factory->createClient();
+        $reflection = new \ReflectionObject($client);
+        $internalClient = $reflection->getProperty('client');
+        $internalClient->setAccessible(true);
+
+        $this->assertInstanceOf(NoPrivateNetworkHttpClient::class, $internalClient->getValue($client));
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #450 
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

Adds a factory for Symfony's `NoPrivateNetworkHttpClient`


#### Why?

While you can just wrap it yourself, it gets annoying when you're trying to inject other non Symfony clients in unit tests (mock client)


#### Example Usage

``` yaml
        webhook:
            http_methods_client: false
            factory: 'httplug.factory.symfony_no_private_network'
```


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] Please tell me if you're actually OK with something like this, if so I'll add it to the docs and changelog
