### PR TITLE
add ThrottlePlugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.0 || ^5.0",
         "nyholm/nsa": "^1.1",
         "nyholm/psr7": "^1.2.1",
-        "php-http/throttle-plugin": "^1.1",
         "php-http/cache-plugin": "^1.7",
         "php-http/mock-client": "^1.2",
         "php-http/promise": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.0 || ^5.0",
         "nyholm/nsa": "^1.1",
         "nyholm/psr7": "^1.2.1",
+        "php-http/throttle-plugin": "^1.1",
         "php-http/cache-plugin": "^1.7",
         "php-http/mock-client": "^1.2",
         "php-http/promise": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "php-http/guzzle6-adapter": "<1.1",
         "php-http/cache-plugin": "<1.7.0",
         "php-http/curl-client": "<2.0",
-        "php-http/socket-client": "<2.0"
+        "php-http/socket-client": "<2.0",
+        "php-http/throttle-plugin": "<1.1"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.7 || ^2.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -630,8 +630,9 @@ class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('name')->end()
-                ->scalarNode('tokens')->defaultValue(1)->end()
-                ->scalarNode('max_time')->defaultNull()->end()
+                ->scalarNode('key')->defaultNull()->end()
+                ->integerNode('tokens')->defaultValue(1)->end()
+                ->floatNode('max_time')->defaultNull()->end()
             ->end()
         ->end();
         // End throttle plugin

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -624,6 +624,17 @@ class Configuration implements ConfigurationInterface
             ->end()
         ->end();
         // End error plugin
+
+        $throttle =  $children->arrayNode('throttle')
+            ->canBeEnabled()
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('name')->end()
+                ->scalarNode('tokens')->defaultValue(1)->end()
+                ->scalarNode('max_time')->defaultNull()->end()
+            ->end()
+        ->end();
+        // End throttle plugin
     }
 
     /**

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -625,7 +625,7 @@ class Configuration implements ConfigurationInterface
         ->end();
         // End error plugin
 
-        $throttle =  $children->arrayNode('throttle')
+        $throttle = $children->arrayNode('throttle')
             ->canBeEnabled()
             ->addDefaultsIfNotSet()
             ->children()

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -10,6 +10,7 @@ use Http\Client\Common\FlexibleHttpClient;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\HttpMethodsClientInterface;
 use Http\Client\Common\Plugin\AuthenticationPlugin;
+use Http\Client\Common\Plugin\ThrottlePlugin;
 use Http\Client\Common\PluginClient;
 use Http\Client\Common\PluginClientFactory;
 use Http\Client\HttpAsyncClient;
@@ -294,6 +295,14 @@ class HttplugExtension extends Extension
                 break;
 
             case 'throttle':
+                if (!\interface_exists(LimiterInterface::class)) {
+                    throw new InvalidConfigurationException('You need to require the Rate Limiter to be able to use it: "composer require symfony/rate-limiter".');
+                }
+
+                if (!\class_exists(ThrottlePlugin::class)) {
+                    throw new InvalidConfigurationException('You need to require the Throttle Plugin to be able to use it: "composer require php-http/throttle-plugin".');
+                }
+
                 $key = $config['name'] ? '.'.$config['name'] : '';
                 $container
                     ->register($serviceId.$key, LimiterInterface::class)

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -292,6 +292,15 @@ class HttplugExtension extends Extension
 
                 break;
 
+            case 'throttle':
+                $definition->replaceArgument(0, new Reference('rate_limiter.'.$config['name']));
+                $definition->addArgument([
+                    'tokens' => $config['tokens'],
+                    'maxTime' => $config['max_time'],
+                ]);
+
+                break;
+
             /* client specific plugins */
 
             case 'add_host':

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -295,10 +295,6 @@ class HttplugExtension extends Extension
                 break;
 
             case 'throttle':
-                if (!\interface_exists(LimiterInterface::class)) {
-                    throw new InvalidConfigurationException('You need to require the Rate Limiter to be able to use it: "composer require symfony/rate-limiter".');
-                }
-
                 if (!\class_exists(ThrottlePlugin::class)) {
                     throw new InvalidConfigurationException('You need to require the Throttle Plugin to be able to use it: "composer require php-http/throttle-plugin".');
                 }

--- a/src/Resources/config/plugins.xml
+++ b/src/Resources/config/plugins.xml
@@ -28,6 +28,9 @@
         <service id="httplug.plugin.stopwatch" class="Http\Client\Common\Plugin\StopwatchPlugin" public="false" abstract="true">
             <argument />
         </service>
+        <service id="httplug.plugin.throttle" class="Http\Client\Common\Plugin\ThrottlePlugin" public="false" abstract="true">
+            <argument />
+        </service>
 
         <!-- client specific plugin definition prototypes -->
 

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -315,7 +315,6 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 ],
                 'throttle' => [
                     'enabled' => false,
-                    'name' => 'limit',
                     'tokens' => 1,
                     'max_time' => null,
                 ],

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -316,6 +316,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 ],
                 'throttle' => [
                     'enabled' => false,
+                    'key' => null,
                     'tokens' => 1,
                     'max_time' => null,
                 ],

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -100,6 +100,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             ],
             'throttle' => [
                 'enabled' => false,
+                'key' => null,
                 'tokens' => 1,
                 'max_time' => null,
             ],

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -98,6 +98,11 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'enabled' => false,
                 'only_server_exception' => false,
             ],
+            'throttle' => [
+                'enabled' => false,
+                'tokens' => 1,
+                'max_time' => null,
+            ],
         ],
         'discovery' => [
             'client' => 'auto',
@@ -307,6 +312,12 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'error' => [
                     'enabled' => false,
                     'only_server_exception' => false,
+                ],
+                'throttle' => [
+                    'enabled' => false,
+                    'name' => 'limit',
+                    'tokens' => 1,
+                    'max_time' => null,
                 ],
             ],
             'discovery' => [

--- a/tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -162,11 +162,6 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
                                 'only_server_exception' => true,
                             ],
                         ],
-                        [
-                            'throttle' => [
-                                'name' => 'test',
-                            ],
-                        ],
                     ],
                 ],
             ],

--- a/tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -184,7 +184,6 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
             'httplug.client.acme.authentication.my_basic',
             'httplug.client.acme.plugin.cache',
             'httplug.client.acme.plugin.error',
-            'httplug.client.acme.plugin.throttle',
         ];
         $pluginReferences = array_map(function ($id) {
             return new Reference($id);

--- a/tests/Unit/DependencyInjection/HttplugExtensionTest.php
+++ b/tests/Unit/DependencyInjection/HttplugExtensionTest.php
@@ -162,6 +162,11 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
                                 'only_server_exception' => true,
                             ],
                         ],
+                        [
+                            'throttle' => [
+                                'name' => 'test',
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -184,6 +189,7 @@ class HttplugExtensionTest extends AbstractExtensionTestCase
             'httplug.client.acme.authentication.my_basic',
             'httplug.client.acme.plugin.cache',
             'httplug.client.acme.plugin.error',
+            'httplug.client.acme.plugin.throttle',
         ];
         $pluginReferences = array_map(function ($id) {
             return new Reference($id);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

Add config settings for ThrottlePlugin

#### Why?

Adding the plugin without using configurations causes inconvenience.

### Example

        default:
            factory: 'httplug.factory.curl'
            config:
                CURLOPT_TIMEOUT: 10
            plugins:
                - throttle:
                      name: default
                      key: default
                      tokens: 1
                      max_time: 1