### PR TITLE
throttle plugin requires a name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 # Version 1
 
+# 1.34.1 - 2024-09-01
+
+- The rate-limiter name in the throttle plugin configuration is required.
+
 # 1.34.0 - 2024-06-17
 
 - Support to configure the throttle plugin.

--- a/composer.json
+++ b/composer.json
@@ -50,18 +50,19 @@
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.7 || ^2.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.0 || ^5.0",
+        "matthiasnoback/symfony-config-test": "^4.3 || ^5.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.3.1 || ^5.0",
         "nyholm/nsa": "^1.1",
         "nyholm/psr7": "^1.2.1",
         "php-http/cache-plugin": "^1.7",
         "php-http/mock-client": "^1.2",
         "php-http/promise": "^1.0",
+        "phpunit/phpunit": "^9.6",
         "symfony/browser-kit": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/http-foundation": "^4.4.19 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^6.4.1",
         "symfony/stopwatch": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/twig-bundle": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/web-profiler-bundle": "^4.4.19 || ^5.0 || ^6.0 || ^7.0",
@@ -97,7 +98,7 @@
     },
     "prefer-stable": false,
     "scripts": {
-        "test": "vendor/bin/simple-phpunit",
-        "test-ci": "vendor/bin/simple-phpunit --coverage-text --coverage-clover=build/coverage.xml"
+        "test": "vendor/bin/phpunit",
+        "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -616,7 +616,7 @@ class Configuration implements ConfigurationInterface
         ->end();
         // End stopwatch plugin
 
-        $error = $children->arrayNode('error')
+        $children->arrayNode('error')
             ->canBeEnabled()
             ->addDefaultsIfNotSet()
             ->children()
@@ -625,11 +625,14 @@ class Configuration implements ConfigurationInterface
         ->end();
         // End error plugin
 
-        $throttle = $children->arrayNode('throttle')
+        $children->arrayNode('throttle')
             ->canBeEnabled()
             ->addDefaultsIfNotSet()
             ->children()
-                ->scalarNode('name')->end()
+                ->scalarNode('name')
+                    ->info('The name of the configured symfony/rate-limiter to use')
+                    ->isRequired()
+                ->end()
                 ->scalarNode('key')->defaultNull()->end()
                 ->integerNode('tokens')->defaultValue(1)->end()
                 ->floatNode('max_time')->defaultNull()->end()

--- a/src/DependencyInjection/HttplugExtension.php
+++ b/src/DependencyInjection/HttplugExtension.php
@@ -299,14 +299,13 @@ class HttplugExtension extends Extension
                     throw new InvalidConfigurationException('You need to require the Throttle Plugin to be able to use it: "composer require php-http/throttle-plugin".');
                 }
 
-                $key = $config['name'] ? '.'.$config['name'] : '';
                 $container
-                    ->register($serviceId.$key, LimiterInterface::class)
+                    ->register($serviceId.$config['name'], LimiterInterface::class)
                     ->setFactory([new Reference('limiter.'.$config['name']), 'create'])
                     ->addArgument($config['key'])
                     ->setPublic(false);
 
-                $definition->replaceArgument(0, new Reference($serviceId.$key));
+                $definition->replaceArgument(0, new Reference($serviceId.$config['name']));
                 $definition->setArgument('$tokens', $config['tokens']);
                 $definition->setArgument('$maxTime', $config['max_time']);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | (no) if the name option for the throttle plugin was not specified, 1.34.0 did not report invalid configuration, but the extension class was broken and if php ignored the undefined array key, the plugin can not be instantiated because the service does not exist.
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Throttle plugin references a symfony/rate-limiter service with the `name`. This is not optional.

