### PR TITLE
Remove deprecated spaceless filter

### DIFF
--- a/src/Resources/views/stack.html.twig
+++ b/src/Resources/views/stack.html.twig
@@ -7,16 +7,14 @@
         {% endif %}
         <span class="label httplug-method httplug-method-{{ stack.requestMethod|lower }}">{{ stack.requestMethod }}</span>
     </div>
-    {% apply spaceless %}
-        <div class="label httplug-stack-header-target">
-            <span class="httplug-scheme">{{ stack.requestScheme }}://</span>
-            <span class="httplug-host">{{ stack.requestHost }}</span>
-            {% if stack.requestPort not in [null, 80, 443] %}
-                <span class="httplug-port">:{{ stack.requestPort }}</span>
-            {% endif %}
-            <span class="httplug-target">{{ (stack.requestTarget|default('/') starts with '/' ? '' : '/')  ~ stack.requestTarget }}</span>
-        </div>
-    {% endapply %}
+    <div class="label httplug-stack-header-target">
+        <span class="httplug-scheme">{{ stack.requestScheme }}://</span>
+        <span class="httplug-host">{{ stack.requestHost }}</span>
+        {% if stack.requestPort not in [null, 80, 443] %}
+            <span class="httplug-port">:{{ stack.requestPort }}</span>
+        {% endif %}
+        <span class="httplug-target">{{ (stack.requestTarget|default('/') starts with '/' ? '' : '/')  ~ stack.requestTarget }}</span>
+    </div>
     <div>
         <span class="label httplug-duration">{{ stack.duration|number_format }} ms</span>
         {% if stack.responseCode >= 400 and stack.responseCode <= 599 %}

--- a/tests/Functional/ProfilerTest.php
+++ b/tests/Functional/ProfilerTest.php
@@ -28,7 +28,7 @@ class ProfilerTest extends WebTestCase
         $client->request('GET', '/_profiler/latest?panel=httplug');
         $content = $client->getResponse()->getContent();
         $this->assertStringContainsString(<<<HTML
-            <div class="label httplug-stack-header-target"><span class="httplug-scheme">https://</span><span class="httplug-host">jsonplaceholder.typicode.com</span><span class="httplug-target">/posts/1</span></div>
-        HTML, $content);
+        <div class="label httplug-stack-header-target"><span class="httplug-scheme">https://</span><span class="httplug-host">jsonplaceholder.typicode.com</span><span class="httplug-target">/posts/1</span></div>
+        HTML, str_replace(" ", "", $content));
     }
 }

--- a/tests/Functional/ProfilerTest.php
+++ b/tests/Functional/ProfilerTest.php
@@ -28,7 +28,7 @@ class ProfilerTest extends WebTestCase
         $client->request('GET', '/_profiler/latest?panel=httplug');
         $content = $client->getResponse()->getContent();
         $this->assertStringContainsString(<<<HTML
-        <div class="label httplug-stack-header-target"><span class="httplug-scheme">https://</span><span class="httplug-host">jsonplaceholder.typicode.com</span><span class="httplug-target">/posts/1</span></div>
-        HTML, str_replace([' ', "\n"], ['', ''], $content));
+        <span class="httplug-host">jsonplaceholder.typicode.com</span>
+        HTML, $content);
     }
 }

--- a/tests/Functional/ProfilerTest.php
+++ b/tests/Functional/ProfilerTest.php
@@ -29,6 +29,6 @@ class ProfilerTest extends WebTestCase
         $content = $client->getResponse()->getContent();
         $this->assertStringContainsString(<<<HTML
         <div class="label httplug-stack-header-target"><span class="httplug-scheme">https://</span><span class="httplug-host">jsonplaceholder.typicode.com</span><span class="httplug-target">/posts/1</span></div>
-        HTML, str_replace(" ", "", $content));
+        HTML, str_replace(' ', '', $content));
     }
 }

--- a/tests/Functional/ProfilerTest.php
+++ b/tests/Functional/ProfilerTest.php
@@ -29,6 +29,6 @@ class ProfilerTest extends WebTestCase
         $content = $client->getResponse()->getContent();
         $this->assertStringContainsString(<<<HTML
         <div class="label httplug-stack-header-target"><span class="httplug-scheme">https://</span><span class="httplug-host">jsonplaceholder.typicode.com</span><span class="httplug-target">/posts/1</span></div>
-        HTML, str_replace(' ', '', $content));
+        HTML, str_replace([' ', "\n"], ['', ''], $content));
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

> Since twig/twig 3.12: Twig Filter "spaceless" is deprecated

See https://github.com/twigphp/Twig/pull/4236

