### PR TITLE
add autowiring alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 - Removed the `Http\Client\HttpClient` alias use the `Psr\Http\Client\ClientInterface` typehint in your services for autowiring.
 - Changed classes marked as `@final` to be actually `final`. If you extended any of those, instead implement interfaces or decorate the class rather than extending it. Open an issue if you think a class needs to be made non-final to discuss what we should do.
 - Added return type declaration to `Http\HttplugBundle\ClientFactory\ClientFactory::createClient`
+- Added interface name alias for the `Http\Mock\Client` and all PSR17 factories to help with autowiring.
 
 # Version 1
 

--- a/src/Resources/config/mock-client.xml
+++ b/src/Resources/config/mock-client.xml
@@ -5,6 +5,7 @@
 
     <services>
         <service id="httplug.client.mock" class="Http\Mock\Client" public="true" />
+        <service id="Http\Mock\Client" alias="httplug.client.mock" public="true"/>
         <service id="httplug.factory.mock" class="Http\HttplugBundle\ClientFactory\MockFactory" public="false">
             <call method="setClient">
                 <argument type="service" id="httplug.client.mock" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -41,21 +41,32 @@
         <service id="httplug.psr17_request_factory.default" class="Psr\Http\Message\RequestFactoryInterface">
             <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findRequestFactory" />
         </service>
+        <service id="Psr\Http\Message\RequestFactoryInterface" alias="httplug.psr17_request_factory.default" public="true"/>
+
         <service id="httplug.psr17_response_factory.default" class="Psr\Http\Message\ResponseFactoryInterface">
             <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findResponseFactory" />
         </service>
+        <service id="Psr\Http\Message\ResponseFactoryInterface" alias="httplug.psr17_response_factory.default" public="true"/>
+
         <service id="httplug.psr17_stream_factory.default" class="Psr\Http\Message\StreamFactoryInterface">
             <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findStreamFactory" />
         </service>
+        <service id="Psr\Http\Message\StreamFactoryInterface" alias="httplug.psr17_stream_factory.default" public="true"/>
+
         <service id="httplug.psr17_uri_factory.default" class="Psr\Http\Message\UriFactoryInterface">
             <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findUrlFactory" />
         </service>
+        <service id="Psr\Http\Message\UriFactoryInterface" alias="httplug.psr17_uri_factory.default" public="true"/>
+
         <service id="httplug.psr17_uploaded_file_factory.default" class="Psr\Http\Message\UploadedFileFactoryInterface">
             <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findUploadedFileFactory" />
         </service>
+        <service id="Psr\Http\Message\UploadedFileFactoryInterface" alias="httplug.psr17_uploaded_file_factory.default" public="true"/>
+
         <service id="httplug.psr17_server_request_factory.default" class="Psr\Http\Message\ServerRequestFactoryInterface">
             <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findServerRequestFactory" />
         </service>
+        <service id="Psr\Http\Message\ServerRequestFactoryInterface" alias="httplug.psr17_server_request_factory.default" public="true"/>
 
         <!-- PluginClientFactory -->
         <service id="Http\Client\Common\PluginClientFactory" class="Http\Client\Common\PluginClientFactory" public="false" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | not really (but if people have defined their own alias, there could be side effects from this change)
| Deprecations?   | no
| Related tickets | fixes #474 
| Documentation   | https://github.com/php-http/documentation/pull/324
| License         | MIT


#### What's in this PR?

Add alias to psr17 factories


#### Why?

to support symfony autowiring

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)
