### PR TITLE
fix: update routing configuration to use PHP files for WebProfilerBundle

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -65,8 +65,8 @@ jobs:
             symfony-require: "6.4.*"
             php-version: "8.2"
             symfony-deprecations-helper: "weak"
-          - dependencies: "php-http/guzzle7-adapter symfony/http-client:^7.1"
-            symfony-require: "7.1.*"
+          - dependencies: "php-http/guzzle7-adapter symfony/http-client:^7.3"
+            symfony-require: "7.3.*"
             php-version: "8.2"
             symfony-deprecations-helper: "weak"
 

--- a/tests/Resources/app/AppKernel.php
+++ b/tests/Resources/app/AppKernel.php
@@ -66,8 +66,9 @@ class AppKernel extends Kernel
         $collection->add('/', new Route('/', ['_controller' => 'kernel::indexAction']));
 
         $routes = new RoutingConfigurator($collection, $kernelLoader, $file, $file);
-        $routes->import('@WebProfilerBundle/Resources/config/routing/wdt.xml')->prefix('_wdt');
-        $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml')->prefix('_profiler');
+        $extension = self::MAJOR_VERSION >= 7 ? 'php' : 'xml';
+        $routes->import('@WebProfilerBundle/Resources/config/routing/wdt.'.$extension)->prefix('_wdt');
+        $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.'.$extension)->prefix('_profiler');
 
         return $collection;
     }

--- a/tests/Resources/app/AppKernel.php
+++ b/tests/Resources/app/AppKernel.php
@@ -66,6 +66,7 @@ class AppKernel extends Kernel
         $collection->add('/', new Route('/', ['_controller' => 'kernel::indexAction']));
 
         $routes = new RoutingConfigurator($collection, $kernelLoader, $file, $file);
+        // TODO hardcode xml when we support only Symfony 7.3 or higher.
         $extension = self::MAJOR_VERSION >= 7 ? 'php' : 'xml';
         $routes->import('@WebProfilerBundle/Resources/config/routing/wdt.'.$extension)->prefix('_wdt');
         $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.'.$extension)->prefix('_profiler');


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
relevant documentation
| License         | MIT


#### What's in this PR?

Use php config files from web-profiler-bundle instead of deprecated XML ones

#### Why?

When running tests locally, I get the following error :

`Cannot load resource "@WebProfilerBundle/Resources/config/routing/wdt.xml". Make sure the "WebProfilerBundle" bundle is correctly registered and loaded in the application kernel class. If the bundle is registered, make sure the bundle path "@WebProfilerBundle/Resources/config/routing/wdt.xml" is not empty.`

Although XML files exist, they can't be loaded in version 7.4 of the bundle 
